### PR TITLE
Implemented automatic background logging

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
           package="net.activitywatch.android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission
             android:name="android.permission.PACKAGE_USAGE_STATS"
             tools:ignore="ProtectedPermissions"/>
@@ -27,6 +28,15 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-    </application>
 
+        <receiver
+                android:name=".watcher.AlarmReceiver"
+                android:enabled="true"
+            >
+            <intent-filter>
+                <action android:name="net.activitywatch.android.watcher.LOG_DATA"/>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
+        </receiver>
+    </application>
 </manifest>

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -60,6 +60,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         val ri = RustInterface(this)
         ri.startServerTask(this)
 
+        val usw = UsageStatsWatcher(this)
+        usw.setupAlarm()
+
         val firstFragment = TestFragment()
         supportFragmentManager.beginTransaction()
             .add(R.id.fragment_container, firstFragment).commit()
@@ -68,9 +71,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onResume() {
         super.onResume()
 
-        // Temporarily disabled until bugs are kinked out
-        //val usw = UsageStatsWatcher(this)
-        //usw.sendHeartbeats()
+        // Ensures data is always fresh when app is opened,
+        // even if it was up to an hour since the last logging-alarm was triggered.
+        val usw = UsageStatsWatcher(this)
+        usw.sendHeartbeats()
     }
 
     override fun onBackPressed() {

--- a/mobile/src/main/java/net/activitywatch/android/watcher/AlarmReceiver.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/AlarmReceiver.kt
@@ -1,0 +1,27 @@
+package net.activitywatch.android.watcher
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+private const val TAG = "AlarmReceiver"
+
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.w(TAG, "AlarmReceiver called")
+        val usw = UsageStatsWatcher(context)
+        if (intent.action == "android.intent.action.BOOT_COMPLETED") {
+            // FIXME: Doesn't seem to be triggered as it should
+            Log.w(TAG, "Received BOOT_COMPLETED, setting up alarm")
+            usw.setupAlarm()
+        } else if(intent.action == "net.activitywatch.android.watcher.LOG_DATA") {
+            Log.w(TAG, "Action ${intent.action}, running sendHeartbeats")
+            if(usw.isUsageAllowed()) {
+                usw.sendHeartbeats()
+            }
+        } else {
+            Log.w(TAG, "Unknown intent $intent with action ${intent.action}, doing nothing")
+        }
+    }
+}


### PR DESCRIPTION
With this, the Android app is basically ready to be used without the absolutely terrible UX of having to click a button to log data.

The alarm is needed to make sure data is logged even if the user doesn't open the app in several days. Also helps ensure data is logged in smaller batches (hourly) and not in huge days-long batches (that might take a while).