### PR TITLE
Add ChromeWatcher

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -38,5 +38,14 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
         </receiver>
+
+        <service android:name=".watcher.ChromeWatcher"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService"/>
+            </intent-filter>
+            <meta-data android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
     </application>
 </manifest>

--- a/mobile/src/main/java/net/activitywatch/android/watcher/ChromeWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/ChromeWatcher.kt
@@ -1,0 +1,136 @@
+package net.activitywatch.android.watcher
+
+import android.accessibilityservice.AccessibilityService
+import android.annotation.TargetApi
+import android.app.AlarmManager
+import android.app.AppOpsManager
+import android.app.PendingIntent
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.*
+import android.provider.Settings
+import android.support.annotation.RequiresApi
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.Toast
+import net.activitywatch.android.R
+import net.activitywatch.android.RustInterface
+import net.activitywatch.android.models.Event
+import org.json.JSONObject
+import org.threeten.bp.DateTimeUtils
+import org.threeten.bp.Duration
+import org.threeten.bp.Instant
+import java.net.URL
+import java.text.ParseException
+import java.text.SimpleDateFormat
+
+class ChromeWatcher : AccessibilityService() {
+
+    private val TAG = "ChromeWatcher"
+    private val bucket_id = "aw-watcher-android-web-chrome"
+
+    private var ri : RustInterface? = null
+
+    var lastUrlTimestamp : Instant? = null
+    var lastUrl : String? = null
+    var lastTitle : String? = null
+
+    override fun onCreate() {
+        ri = RustInterface(applicationContext)
+        ri?.createBucketHelper(bucket_id, "web.tab.current")
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent) {
+
+        // TODO: This method is called very often, which might affect performance. Future optimizations needed.
+
+        // Only track Chrome and System events
+        if (event.packageName != "com.android.chrome" && event.packageName != "com.android.systemui") {
+            onUrl(null)
+            return
+        }
+
+        try {
+            if (event != null && event.source != null) {
+                // Get URL
+                val urlBars = event.source.findAccessibilityNodeInfosByViewId("com.android.chrome:id/url_bar")
+                if (urlBars.any()) {
+                    val newUrl = "http://" + urlBars[0].text.toString() // TODO: We can't access the URI scheme, so we assume HTTP.
+                    onUrl(newUrl)
+                }
+
+                // Get title
+                var webView = findWebView(event.source)
+                if (webView != null) {
+                    lastTitle = webView.text.toString()
+                    Log.i(TAG, "Title: ${lastTitle}")
+                }
+            }
+        }
+        catch(ex : Exception) {
+            Log.e(TAG, ex.message)
+        }
+    }
+
+    fun findWebView(info : AccessibilityNodeInfo) : AccessibilityNodeInfo? {
+        if(info == null)
+            return null
+
+        if(info.className == "android.webkit.WebView" && info.text != null)
+            return info
+
+        for (i in 0 until info.childCount) {
+            val child = info.getChild(i)
+            val webView = findWebView(child)
+            if (webView != null) {
+                return webView
+            }
+            if(child != null){
+                child.recycle()
+            }
+        }
+
+        return null
+    }
+
+    fun onUrl(newUrl : String?) {
+        Log.i(TAG, "Url: ${newUrl}")
+        if (newUrl != lastUrl) { // URL changed
+            if (lastUrl != null) {
+                // Log last URL and title as a completed browser event.
+                // We wait for the event to complete (marked by a change in URL) to ensure that
+                // we had a chance to receive the title of the page, which often only arrives after
+                // the page loads completely and/or the user interacts with the page.
+                logBrowserEvent(lastUrl!!, lastTitle ?: "", lastUrlTimestamp!!)
+            }
+
+            lastUrlTimestamp = Instant.ofEpochMilli(System.currentTimeMillis())
+            lastUrl = newUrl
+            lastTitle = null
+        }
+    }
+
+    fun logBrowserEvent(url: String, title: String, lastUrlTimestamp : Instant) {
+        val now = Instant.ofEpochMilli(System.currentTimeMillis())
+        val start = lastUrlTimestamp
+        val end = now
+        val duration = Duration.between(start, end)
+
+        val data = JSONObject()
+        data.put("url", url)
+        data.put("title", title)
+        data.put("audible", false) // TODO
+        data.put("incognito", false) // TODO
+
+        ri?.heartbeatHelper(bucket_id, start, duration.seconds.toDouble(), data, 1.0)
+    }
+
+    override fun onInterrupt() {
+        TODO("not implemented")
+    }
+}

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
         "\n<b>If you\'re new to ActivityWatch</b>, you should also check out the <a href='https://activitywatch.net/'>desktop version of ActivityWatch</a>."
     </string>
     <string name="button_log_text">Click me to log data!</string>
+    <string name="accessibility_service_description">Allows ActivityWatch to read the URL and title from your browser.</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>

--- a/mobile/src/main/res/xml/accessibility_service_config.xml
+++ b/mobile/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/accessibility_service_description"
+    android:accessibilityEventTypes="typeWindowContentChanged|typeWindowsChanged|typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:notificationTimeout="100"
+    android:accessibilityFlags="flagDefault|flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:canRetrieveWindowContent="true" />


### PR DESCRIPTION
**ChromeWatcher** is a watcher for Chrome. It's implemented as an accessibility service that, when enabled, is allowed to read the URL and title of Chrome's current tab.

Here's what it looks like:
![image](https://user-images.githubusercontent.com/1556332/78201055-a27bed80-745e-11ea-8df2-eddfe5fb0875.png)

Discussed here: https://forum.activitywatch.net/t/android-chrome-watcher/466

Fixes issue #29 (for Chrome at least).