### PR TITLE
Removed duplication of events

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -151,7 +151,11 @@ class UsageStatsWatcher constructor(val context: Context) {
             val usm = getUSM() ?: return 0
 
             var heartbeatsSent = 0
-            val usageEvents = usm.queryEvents(lastUpdated?.toEpochMilli() ?: 0L, Long.MAX_VALUE)
+            var fromTime = 0L
+            if(lastUpdated != null){
+                fromTime = lastUpdated!!.toEpochMilli() + 1
+            }
+            val usageEvents = usm.queryEvents(fromTime, Long.MAX_VALUE)
             nextEvent@ while(usageEvents.hasNextEvent()) {
                 val event = UsageEvents.Event()
                 usageEvents.getNextEvent(event)


### PR DESCRIPTION
`queryEvents()` is inclusive on startTime and endTime, therefore if we use the endTime of the last event, the last event will get added again to the database

I'm not too familiar with Kotlin syntax so please have a look to make sure its correct