### PR TITLE
fixed zero-duration bug

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -155,7 +155,7 @@ class UsageStatsWatcher constructor(val context: Context) {
             nextEvent@ while(usageEvents.hasNextEvent()) {
                 val event = UsageEvents.Event()
                 usageEvents.getNextEvent(event)
-                if(event.eventType !in arrayListOf(UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.ACTIVITY_PAUSED, UsageEvents.Event.SCREEN_INTERACTIVE, UsageEvents.Event.SCREEN_NON_INTERACTIVE)) {
+                if(event.eventType !in arrayListOf(UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.ACTIVITY_PAUSED)) {
                     // Not sure which events are triggered here, so we use a (probably safe) fallback
                     //Log.d(TAG, "Rare eventType: ${event.eventType}, skipping")
                     continue@nextEvent
@@ -164,14 +164,12 @@ class UsageStatsWatcher constructor(val context: Context) {
                 val awEvent = Event.fromUsageEvent(event, context, includeClassname = true)
                 val pulsetime: Double
                 when(event.eventType) {
-                    UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.SCREEN_INTERACTIVE -> {
-                        // MOVE_TO_FOREGROUND: New Activity was opened
-                        // SCREEN_INTERACTIVE: Screen just became interactive, user was previously therefore not active on the device
+                    UsageEvents.Event.ACTIVITY_RESUMED -> {
+                        // ACTIVITY_RESUMED: Activity was opened/reopened
                         pulsetime = 1.0
                     }
-                    UsageEvents.Event.ACTIVITY_PAUSED, UsageEvents.Event.SCREEN_NON_INTERACTIVE -> {
-                        // MOVE_TO_BACKGROUND: Activity was moved to background
-                        // SCREEN_NOT_INTERACTIVE: Screen locked/turned off, user is therefore now AFK, and this is the last event
+                    UsageEvents.Event.ACTIVITY_PAUSED -> {
+                        // ACTIVITY_PAUSED: Activity was moved to background
                         pulsetime = 24 * 60 * 60.0   // 24h, we will assume events should never grow longer than that
                     }
                     else -> {

--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -140,7 +140,6 @@ class UsageStatsWatcher constructor(val context: Context) {
     }
 
     private inner class SendHeartbeatsTask : AsyncTask<URL, Instant, Int>() {
-        private var heartbeatsSent = 0;
         override fun doInBackground(vararg urls: URL): Int? {
             Log.i(TAG, "Sending heartbeats...")
 
@@ -150,32 +149,19 @@ class UsageStatsWatcher constructor(val context: Context) {
             Log.w(TAG, "lastUpdated: ${lastUpdated?.toString() ?: "never"}")
 
             val usm = getUSM() ?: return 0
+
+            var heartbeatsSent = 0
             val usageEvents = usm.queryEvents(lastUpdated?.toEpochMilli() ?: 0L, Long.MAX_VALUE)
-            // App in last loop iteration if it triggered a SCREEN_NON_INTERACTIVE(i.e AFK), otherwise NULL
-            var queuedAfkEvent : Event? = null
-            // App name in last loop iteration if it triggered a MOVE_TO_FOREGROUND/BACKGROUND, otherwise NULL
-            var prevEventAppName: String? = null
-            val lastEvent = getLastEvent()
-            if(lastEvent != null) {
-                var prevEventData = JSONObject(lastEvent.getString("data"))
-                prevEventAppName = prevEventData.getString("app")
-                Log.w(TAG, "lastAppName: ${prevEventAppName}")
-            }
             nextEvent@ while(usageEvents.hasNextEvent()) {
                 val event = UsageEvents.Event()
                 usageEvents.getNextEvent(event)
                 if(event.eventType !in arrayListOf(UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.ACTIVITY_PAUSED, UsageEvents.Event.SCREEN_INTERACTIVE, UsageEvents.Event.SCREEN_NON_INTERACTIVE)) {
                     // Not sure which events are triggered here, so we use a (probably safe) fallback
                     //Log.d(TAG, "Rare eventType: ${event.eventType}, skipping")
-                    // send the previous afk event if there is no event after this
-                    if(!usageEvents.hasNextEvent() && queuedAfkEvent != null){
-                        sendHeartbeatHelper(queuedAfkEvent,24 * 60 * 60.0)
-                        queuedAfkEvent = null
-                    }
                     continue@nextEvent
                 }
 
-                val currawEvent = Event.fromUsageEvent(event, context, includeClassname = true)
+                val awEvent = Event.fromUsageEvent(event, context, includeClassname = true)
                 val pulsetime: Double
                 when(event.eventType) {
                     UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.SCREEN_INTERACTIVE -> {
@@ -190,81 +176,17 @@ class UsageStatsWatcher constructor(val context: Context) {
                     }
                     else -> {
                         Log.w(TAG, "This should never happen!")
-                        // send the previous afk event if there is no event after this
-                        if(!usageEvents.hasNextEvent() && queuedAfkEvent != null){
-                            sendHeartbeatHelper(queuedAfkEvent,24 * 60 * 60.0)
-                            queuedAfkEvent = null
-                        }
                         continue@nextEvent
                     }
                 }
-                if(usageEvents.hasNextEvent()){
-                    if(queuedAfkEvent != null){
-                        // there is an event in the queue, so it must be sent in this iteration.
-                        // if prev app name matches the current event name, then send current event first to merge the heartbeats
-                        // Note: Only do this if event is not SCREEN_INTERACTIVE type, SCREEN_INTERACTIVE type needs
-                        // to be in the right order with respect to an AFK event(SCREEN_NON_INTERACTIVE)
-                        if(currawEvent.data.getString(("app")) == prevEventAppName && event.eventType != UsageEvents.Event.SCREEN_INTERACTIVE){
-                            sendHeartbeatHelper(currawEvent, pulsetime)
-                            sendHeartbeatHelper(queuedAfkEvent, pulsetime)
-                            queuedAfkEvent = null
-                            // no need to update prevEventAppName since they're equal
-                        }
-                        // otherwise send the queued event first
-                        else {
-                            sendHeartbeatHelper(queuedAfkEvent, pulsetime)
-                            queuedAfkEvent = null
-                            // if curr event is AFK, queue it instead
-                            if(event.eventType == UsageEvents.Event.SCREEN_NON_INTERACTIVE){
-                                queuedAfkEvent = currawEvent
-                            }
-                            else{ //otherwise send it
-                                sendHeartbeatHelper(currawEvent, pulsetime)
-                                prevEventAppName = currawEvent.data.getString("app")
-                            }
-                        }
-                    }
-                    else{
-                        // there is no AfkEvent queued, therefore we can just look at the current event
 
-                        // if current event is noninteractive(i.e AFK), don't send it, queue it instead
-                        if(event.eventType == UsageEvents.Event.SCREEN_NON_INTERACTIVE){
-                            queuedAfkEvent = currawEvent
-                        }
-                        else{ // current event is active, so send it
-                            sendHeartbeatHelper(currawEvent, pulsetime)
-                            prevEventAppName = currawEvent.data.getString("app")
-                        }
-                    }
+                ri.heartbeatHelper(bucket_id, awEvent.timestamp, awEvent.duration, awEvent.data, pulsetime)
+                if(heartbeatsSent % 100 == 0) {
+                    publishProgress(awEvent.timestamp)
                 }
-                else{
-                    if(queuedAfkEvent != null){
-                        // there is a queued event, so need to send it in this iteration
-
-                        // if currEvent matches last event, send curr first then the queuedAfkevent
-                        if(currawEvent.data.getString(("app")) == prevEventAppName && event.eventType != UsageEvents.Event.SCREEN_INTERACTIVE){
-                            sendHeartbeatHelper(currawEvent, pulsetime)
-                            sendHeartbeatHelper(queuedAfkEvent, pulsetime)
-                        }
-                        else{ // otherwise send events in normal order
-                            sendHeartbeatHelper(queuedAfkEvent, pulsetime)
-                            sendHeartbeatHelper(currawEvent, pulsetime)
-                        }
-                    }
-                    else{ // no queued event, so send current one
-                        sendHeartbeatHelper(currawEvent, pulsetime)
-                    }
-                }
+                heartbeatsSent++
             }
             return heartbeatsSent
-        }
-        private fun sendHeartbeatHelper(awEvent: Event, pulsetime: Double){
-            Log.w(TAG,awEvent.toString())
-            ri.heartbeatHelper(bucket_id, awEvent.timestamp, awEvent.duration, awEvent.data, pulsetime)
-            if(heartbeatsSent % 100 == 0) {
-                publishProgress(awEvent.timestamp)
-            }
-            heartbeatsSent++
         }
 
         override fun onProgressUpdate(vararg progress: Instant) {


### PR DESCRIPTION
Fixes #34, #39, and parts of ActivityWatch/activitywatch/issues/440

If event is AFK(screen_non_interactive), it is stored as queuedAfkEvent, and you move on to next item. On next item, if the app name of current event matches event before queuedAfkEvent, then you send new item first, and then the afk event (to allow them to be merged as 1 event by AW), otherwise if they have different names, send queuedAfkEvent first, and then current event