### PR TITLE
ci: switched to using rust-android-gradle for building aw-server-rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: aw-webui
+.PHONY: aw-webui apk
 SHELL := /bin/bash
 
 # We should probably do this the "Android way" (would also help with getting it on FDroid):
@@ -8,56 +8,11 @@ SHELL := /bin/bash
 RELEASE_TYPE = $(shell $$RELEASE && echo 'release' || echo 'debug')
 
 # Main targets
-all: aw-server-rust aw-webui
+all: aw-webui apk
 build: all
 
-
-# aw-server-rust stuff
-
-RS_SRCDIR := aw-server-rust
-RS_OUTDIR := $(JNILIBS)
-RS_SOURCES := $(shell find $(RS_SRCDIR)/aw-* -type f -name '*.rs')
-
-JNILIBS := mobile/src/main/jniLibs
-JNI_arm8 := $(JNILIBS)/arm64-v8a
-JNI_arm7 := $(JNILIBS)/armeabi-v7a
-JNI_x86 := $(JNILIBS)/x86
-JNI_x64 := $(JNILIBS)/x86_64
-
-TARGET := aw-server-rust/target
-TARGET_arm7 := $(TARGET)/armv7-linux-androideabi
-TARGET_arm8 := $(TARGET)/aarch64-linux-android
-TARGET_x64 := $(TARGET)/x86_64-linux-android
-TARGET_x86 := $(TARGET)/i686-linux-android
-
-aw-server-rust: $(JNILIBS)
-
-.PHONY: $(JNILIBS)
-$(JNILIBS): $(JNI_arm7)/libaw_server.so $(JNI_arm8)/libaw_server.so $(JNI_x86)/libaw_server.so $(JNI_x64)/libaw_server.so
-	ls -lL $@/*/*  # Check that symlinks are valid
-
-# There must be a better way to do this without repeating almost the same rule over and over?
-$(JNI_arm7)/libaw_server.so: $(TARGET_arm7)/$(RELEASE_TYPE)/libaw_server.so
-	mkdir -p $$(dirname $@)
-	ln -sfnv $$(pwd)/$^ $@
-$(JNI_arm8)/libaw_server.so: $(TARGET_arm8)/$(RELEASE_TYPE)/libaw_server.so
-	mkdir -p $$(dirname $@)
-	ln -sfnv $$(pwd)/$^ $@
-$(JNI_x86)/libaw_server.so: $(TARGET_x86)/$(RELEASE_TYPE)/libaw_server.so
-	mkdir -p $$(dirname $@)
-	ln -sfnv $$(pwd)/$^ $@
-$(JNI_x64)/libaw_server.so: $(TARGET_x64)/$(RELEASE_TYPE)/libaw_server.so
-	mkdir -p $$(dirname $@)
-	ln -sfnv $$(pwd)/$^ $@
-
-# This target runs multiple times because it's matched multiple times, not sure how to fix
-$(RS_SRCDIR)/target/%/$(RELEASE_TYPE)/libaw_server.so: $(RS_SOURCES)
-	echo $@
-	cd aw-server-rust && env RUSTFLAGS="-C debuginfo=2 -Awarnings" bash compile-android.sh
-#	Explanation of RUSTFLAGS:
-#	  `-Awarnings` allows all warnings, for cleaner output (warnings should be detected in aw-server-rust CI anyway)
-#     `-C debuginfo=2` is to keep debug symbols, even in release builds (later stripped by gradle on production builds, non-stripped versions needed for stack resymbolizing with ndk-stack)
-
+apk:
+	env RUSTFLAGS="-C debuginfo=2 -Awarnings" TERM=xterm ./gradlew build
 
 # aw-webui
 

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -82,6 +82,7 @@ cargo {
 
 tasks.whenTaskAdded { task ->
     // Build aw-server-rust
+    // Doesn't work, chokes on building openssl-sys
     if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
         task.dependsOn 'cargoBuild'
     }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -76,11 +76,12 @@ cargo {
     module  = "../aw-server-rust"       // Or whatever directory contains your Cargo.toml
     libname = "aw_server"          // Or whatever matches Cargo.toml's [package] name.
     targets = ["arm", "arm64", "x86", "x86_64"]  // See bellow for a longer list of options
-    profile = 'release'  // Selects the Cargo release profile (defaults to 'debug')
+    // TODO: Set to 'release' on release builds
+    profile = 'debug'  // Selects the Cargo release profile (defaults to 'debug')
 }
 
 tasks.whenTaskAdded { task ->
-    // TODO: Build aw-server lib here instead of in Makefile?
+    // Build aw-server-rust
     if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
         task.dependsOn 'cargoBuild'
     }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 }
 
 // Can be used to build with: ./gradlew cargoBuild
-// NOTE: Doesn't work, chokes on building openssl-sys
 apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 cargo {
@@ -82,10 +81,9 @@ cargo {
 
 tasks.whenTaskAdded { task ->
     // TODO: Build aw-server lib here instead of in Makefile?
-    // Doesn't work, chokes on building openssl-sys
-    //if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
-    //    task.dependsOn 'cargoBuild'
-    //}
+    if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
+        task.dependsOn 'cargoBuild'
+    }
 
     // TODO: Build aw-webui here?
     //if (task.name.contains("assembleRelease")) {


### PR DESCRIPTION
Should make it a lot easier to build aw-server-rust, which in turn will help with #24.

## TODO

 - [x] Remove the unused Makefile targets
 - [ ] Do we need `RUSTFLAGS="-C debuginfo=2 -Awarnings"`? Perhaps rust-android-gradle sets it for us?
 - [x] Fix openssl-sys issue
    - Seems to have resolved itself?
 - [ ] Make sure it's debuggable
 - [ ] Set reasonable build profile depending on build purpose (https://github.com/mozilla/rust-android-gradle/issues/38)