### PR TITLE
feat: disable check for new releases in aw-android (#114)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ $(RS_SRCDIR)/target/%/$(RELEASE_TYPE)/libaw_server.so: $(RS_SOURCES)
 WEBUI_SRCDIR := aw-server-rust/aw-webui
 WEBUI_OUTDIR := mobile/src/main/assets/webui
 WEBUI_SOURCES := $(shell find $(RS_SRCDIR) -type f -name *.rs)
+export ON_ANDROID := -- --android # Disable check for updates in aw-webui
 
 aw-webui: $(WEBUI_OUTDIR)
 


### PR DESCRIPTION
With the changes in https://github.com/ActivityWatch/aw-webui/pull/225, it will add the `-- --os=android` flag to `npm run build` and `npm run serve`, which passes a variable into Vue that prevents it from rendering the components that check for new updates and display reminders.

Note that running `make aw-webui` in aw-android/aw-server-rust or `make build` in `aw-android/aw-server-rust/aw-webui` will not add the flag, since this is only defined in aw-android/Makefile.