### PR TITLE
ci: fetch builds from aw-server-rust repo, instead of building (and some minor fixes)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         java_version: [1.8]
         node_version: [16]
         ruby_version: ['3.0']
+        rust_build: [false]   # if true, will build aw-server-rust, otherwise will fetch artifact from recent CI run
     steps:
     - uses: actions/checkout@v2
       with:
@@ -42,11 +43,8 @@ jobs:
     # Android SDK & NDK
     - name: Set up Android SDK
       uses: android-actions/setup-android@v2
-    - name: Set up Android NDK
-      uses: nttld/setup-ndk@v1
-      id: setup-ndk
-      with:
-        ndk-version: r21d
+    - name: Install NDK
+      run: sdkmanager "ndk;25.0.8775105"
 
     - name: Set up Node
       uses: actions/setup-node@v1
@@ -79,6 +77,7 @@ jobs:
           ${{ runner.os }}-${{ env.cache-name }}-
     - name: Cache cargo build
       uses: actions/cache@v1
+      if: ${{ matrix.rust_build == 'true' }}
       env:
         cache-name: cargo-build-target
       with:
@@ -90,26 +89,54 @@ jobs:
     # Install fastlane
     - name: Install fastlane
       run: |
-        gem install bundle
+        gem install bundler
         bundle install
 
     # Set up Rust toolchain
     - name: Set up Rust toolchain for Android NDK
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
-        ./aw-server-rust/install-ndk.sh
+        ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk-bundle ./aw-server-rust/install-ndk.sh
 
     # Test
     - name: Test
       run: |
         make test
 
-    # Build
-    - name: Build
+    # Build webui
+    - name: Build webui
+      run: |
+        make aw-webui
+
+    # Build or fetch aw-server-rust artifacts
+    - name: Build aw-server-rust
+      if: ${{ matrix.rust_build == 'true' }}
       env:
         ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
-        make build
+        make aw-server-rust
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      if: ${{ !(matrix.rust_build == 'true') }}
+      with:
+        repo: ActivityWatch/aw-server-rust
+        branch: master
+        workflow: build.yml
+        # Optional, uploaded artifact name,
+        # will download all artifacts if not specified
+        # and extract them in respective subdirectories
+        # https://github.com/actions/download-artifact#download-all-artifacts
+        name: binaries-android
+        path: aw-server-rust/
+        # Optional, the status or conclusion of a completed workflow to search for
+        # Can be one of a workflow conculsion::
+        # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+        # Or a workflow status:
+        # "completed", "in_progress", "queued"
+        # Default: "completed"
+        workflow_conclusion: success
 
-    # TODO: Do release stuff
+    - name: Assemble APK
+      run: |
+        # TODO: Replace with ./scripts/build_apk.sh and related stuff in .travis.yml
+        ./gradlew assembleRelease
+        # TODO: Do other release stuff

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="12">
+        <list size="15">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -18,12 +18,15 @@
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="13" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
+          <item index="14" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="14">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
@@ -35,11 +38,14 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
+          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,9 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/aw-server-rust" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/aw-server-rust/aw-webui" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/aw-server-rust/aw-webui/aw-client-js" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/aw-server-rust/aw-webui/node_modules/aw-client" vcs="Git" />
   </component>
 </project>

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,15 @@ $(JNI_x64)/libaw_server.so: $(TARGET_x64)/$(RELEASE_TYPE)/libaw_server.so
 	mkdir -p $$(dirname $@)
 	ln -sfnv $$(pwd)/$^ $@
 
+RUSTFLAGS_ANDROID="-C debuginfo=2 -Awarnings"
+# Explanation of RUSTFLAGS:
+#  `-Awarnings` allows all warnings, for cleaner output (warnings should be detected in aw-server-rust CI anyway)
+#  `-C debuginfo=2` is to keep debug symbols, even in release builds (later stripped by gradle on production builds, non-stripped versions needed for stack resymbolizing with ndk-stack)
+
 # This target runs multiple times because it's matched multiple times, not sure how to fix
 $(RS_SRCDIR)/target/%/$(RELEASE_TYPE)/libaw_server.so: $(RS_SOURCES)
 	echo $@
-	cd aw-server-rust && env RUSTFLAGS="-C debuginfo=2 -Awarnings" bash compile-android.sh
-#	Explanation of RUSTFLAGS:
-#	  `-Awarnings` allows all warnings, for cleaner output (warnings should be detected in aw-server-rust CI anyway)
-#     `-C debuginfo=2` is to keep debug symbols, even in release builds (later stripped by gradle on production builds, non-stripped versions needed for stack resymbolizing with ndk-stack)
-
+	env RUSTFLAGS=$(RUSTFLAGS_ANDROID) make -C aw-server-rust android
 
 # aw-webui
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
 
@@ -23,6 +23,16 @@ allprojects {
     repositories {
         google()
         jcenter()
+    }
+}
+
+// Ignore indexing of some subdirectories
+apply plugin: 'idea'
+idea {
+    module {
+        excludeDirs += file('aw-server-rust')
+        excludeDirs += file('vendor')
+        excludeDirs += file('NDK')
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,28 +1,29 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
+    buildToolsVersion = '29.0.3'
+    ndkVersion "25.0.8775105"
+
     defaultConfig {
         applicationId "net.activitywatch.android"
         minSdkVersion 23
         targetSdkVersion 29
 
         // Set in CI on tagged commit
-        versionName "0.10-dev"
+        versionName "0.10.0"
 
         // Set in CI by `bundle exec fastlane update_version`
-        versionCode 22
+        versionCode 25
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // WARNING: Never commit this uncommented!
-        //packagingOptions {
-        //    doNotStrip '**/*.so'
-        //}
+        packagingOptions {
+            doNotStrip '**/*.so'
+        }
     }
     buildTypes {
         release {
@@ -37,7 +38,6 @@ android {
         sourceCompatibility = "1.8"
         targetCompatibility = 1.8
     }
-    buildToolsVersion = '29.0.3'
 
     // Never got this to work...
     //if (project.hasProperty("doNotStrip")) {
@@ -57,20 +57,20 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.1'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
 
 // Can be used to build with: ./gradlew cargoBuild

--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -17,7 +17,7 @@ class RustInterface constructor(context: Context? = null) {
 
     init {
         // NOTE: This doesn't work, probably because I can't get gradle to not strip symbols on release builds
-        //Os.setenv("RUST_BACKTRACE", "1", true)
+        Os.setenv("RUST_BACKTRACE", "1", true)
 
         if(context != null) {
             Os.setenv("SQLITE_TMPDIR", context.cacheDir.absolutePath, true)

--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -152,11 +152,18 @@ class UsageStatsWatcher constructor(val context: Context) {
 
             val usm = getUSM() ?: return 0
 
+            // Store activities here that have had a RESUMED but not a PAUSED event.
+            // (to handle out-of-order events)
+            //val activeActivities = [];
+
+            // TODO: Fix issues that occur when usage stats events are out of order (RESUME before PAUSED)
             var heartbeatsSent = 0
             val usageEvents = usm.queryEvents(lastUpdated?.toEpochMilli() ?: 0L, Long.MAX_VALUE)
             nextEvent@ while(usageEvents.hasNextEvent()) {
                 val event = UsageEvents.Event()
                 usageEvents.getNextEvent(event)
+
+                // Log screen unlock
                 if(event.eventType !in arrayListOf(UsageEvents.Event.ACTIVITY_RESUMED, UsageEvents.Event.ACTIVITY_PAUSED)) {
                     if(event.eventType == UsageEvents.Event.KEYGUARD_HIDDEN){
                         val timestamp = DateTimeUtils.toInstant(java.util.Date(event.timeStamp))
@@ -169,6 +176,8 @@ class UsageStatsWatcher constructor(val context: Context) {
                     //Log.d(TAG, "Rare eventType: ${event.eventType}, skipping")
                     continue@nextEvent
                 }
+
+                // Log activity
                 val awEvent = Event.fromUsageEvent(event, context, includeClassname = true)
                 val pulsetime: Double
                 when(event.eventType) {

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="button_log_text">Click me to log data!</string>
     <string name="accessibility_service_description">Allows ActivityWatch to read the URL and title from your browser.</string>
 
+    <!-- This is overridden by gradle config -->
+    <string name="versionName">unknown version</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
Had this in my working tree. Probably super old, not sure if good idea.

 - [ ] Make conditional on if on master-branch or not, such that we only build from scratch for actual releases/nightlies (to speed up PR builds)
    - An alternative could be to only build aw-server-rust for one platform, and not all 3
    - Another alternative/improvement is to parallelize by building aw-server-rust in a job matrix