### PR TITLE
Implement e2e test as android instrumentation Screenshot + CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }}, java-${{ matrix.java_version }}, node-${{ matrix.node_version }}
+    name: Build ${{ matrix.os }}, java-${{ matrix.java_version }}, node-${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     env:
       SUPPLY_TRACK: production   # used by fastlane to determine track to publish to
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        java_version: [1.8]
+        java_version: [11]
         node_version: [16]
         ruby_version: ['3.0']
         rust_build: [false]   # if true, will build aw-server-rust, otherwise will fetch artifact from recent CI run
@@ -101,7 +101,8 @@ jobs:
     # Set up Rust toolchain
     - name: Set up Rust toolchain for Android NDK
       run: |
-        ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk-bundle ./aw-server-rust/install-ndk.sh
+        ANDROID_NDK_HOME=
+        ./aw-server-rust/install-ndk.sh
 
     # Test
     - name: Test
@@ -153,6 +154,7 @@ jobs:
         bundle exec fastlane update_version
 
     - name: Load secrets
+      if: env.KEY_ANDROID_JKS != null
       env:
         KEY_ANDROID_JKS: ${{ secrets.KEY_ANDROID_JKS }}
       run: |
@@ -174,6 +176,338 @@ jobs:
       with:
         name: aw-android
         path: dist/aw-android*.apk
+
+  test:
+    name: Test ${{ matrix.android_avd }} #-${{ matrix.os }}-eAPI-${{ matrix.android_emu_version }}-java-${{ matrix.java_version }}-node-${{ matrix.node_version }}
+    runs-on: ${{ matrix.os }}
+    env:
+      SUPPLY_TRACK: production   # used by fastlane to determine track to publish to
+      MATRIX_E_SDK: ${{ matrix.android_emu_version }}
+      MATRIX_AVD: ${{ matrix.android_avd }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        os: [macos-12] # macOS-latest,
+        android_emu_version: [27] #29, 31, 32]
+        # android_avd: [Pixel_API_29_AOSP]
+        java_version: [11]
+        node_version: [16]
+        ruby_version: ['3.0']
+        rust_build: [false]   # if true, will build aw-server-rust, otherwise will fetch artifact from recent CI run
+        skip_webui: [true]
+        include:
+          - android_avd: Pixel_API_27_AOSP
+            android_emu_version: 27
+          # # # Cannot run > 27-emuLevel -_- https://github.com/actions/runner-images/issues/6527 
+          # - android_avd: Pixel_API_29_AOSP
+          #   android_emu_version: 29
+          # - android_avd: Pixel_API_31_AOSP
+          #   android_emu_version: 31
+          # - android_avd: Pixel_API_32_AOSP
+          #   android_emu_version: 32
+    steps: 
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    # # # Below code is majorly from https://github.com/actions/runner-images/issues/6152#issuecomment-1243718140 
+    - name: Create Android emulator
+      run: |
+        brew install intel-haxm
+        # Install AVD files
+        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-'$MATRIX_E_SDK';default;x86_64'
+        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --licenses
+        
+        # Create emulator
+        $ANDROID_HOME/tools/bin/avdmanager create avd -n $MATRIX_AVD -d pixel --package 'system-images;android-'$MATRIX_E_SDK';default;x86_64'
+        $ANDROID_HOME/emulator/emulator -list-avds
+        if false; then
+        emulator_config=~/.android/avd/$MATRIX_AVD.avd/config.ini
+        # The following madness is to support empty OR populated config.ini files,
+        # the state of which is dependant on the version of the emulator used (which we don't control),
+        # so let's be defensive to be safe.
+        # Replace existing config (NOTE we're on MacOS so sed works differently!)
+        sed -i .bak 's/hw.lcd.density=.*/hw.lcd.density=420/' "$emulator_config"
+        sed -i .bak 's/hw.lcd.height=.*/hw.lcd.height=1920/' "$emulator_config"
+        sed -i .bak 's/hw.lcd.width=.*/hw.lcd.width=1080/' "$emulator_config"
+        # Or, add new config
+        if ! grep -q "hw.lcd.density" "$emulator_config"; then
+          echo "hw.lcd.density=420" >> "$emulator_config"
+        fi
+        if ! grep -q "hw.lcd.height" "$emulator_config"; then
+          echo "hw.lcd.height=1920" >> "$emulator_config"
+        fi
+        if ! grep -q "hw.lcd.width" "$emulator_config"; then
+          echo "hw.lcd.width=1080" >> "$emulator_config"
+        fi
+        echo "Emulator settings ($emulator_config)"
+        cat "$emulator_config"
+        fi
+      
+    - name: Start Android emulator
+      timeout-minutes: 30 # ~4min normal - 3x DOSafety
+      env:
+        SUFFIX: ${{ matrix.android_avd }}-eAPI-${{ matrix.android_emu_version }}-${{ matrix.os }}
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        echo "Starting emulator and waiting for boot to complete...."
+        ls -la $ANDROID_HOME/emulator
+        nohup $ANDROID_HOME/tools/emulator -avd $MATRIX_AVD -gpu host -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
+        $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do echo "wait..."; sleep 1; done; input keyevent 82'
+        echo "Emulator has finished booting"
+        $ANDROID_HOME/platform-tools/adb devices
+        sleep 30
+        screencapture screenshot$SUFFIX.jpg
+        $ANDROID_HOME/platform-tools/adb exec-out screencap -p > emulator$SUFFIX.png
+    # # # Have to re-setup everything since we need to run emulator for faster performance on masOS ? Other os'es emulator will not startup ?
+    # TODO: Optimize the steps taking into consideration all software present by default on macOS runner image
+    # Build in release mode if: (longer build times)
+    #  - on a tag (release)
+    #  - on the master branch (nightly)
+    - name: Set RELEASE
+      run: |
+        echo "RELEASE=${{ startsWith(github.ref_name, 'v') || github.ref_name == 'master' }}" >> $GITHUB_ENV
+
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java_version }}
+
+    # Android SDK & NDK
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+
+    - name: Install NDK
+      run: sdkmanager "ndk;25.0.8775105"
+
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      if: ${{ !matrix.skip_webui }}
+      with:
+        node-version: ${{ matrix.node_version }}
+
+    - name: Set up Rust nightly
+      uses: actions-rs/toolchain@v1
+      if: ${{ matrix.rust_build }}
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+
+    - uses: adnsio/setup-age-action@v1.2.0
+
+    # Set up caches
+    - name: Get npm cache dir
+      id: npm-cache-dir
+      if: ${{ !matrix.skip_webui }}
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+
+    - uses: actions/cache@v1
+      name: Cache npm
+      if: ${{ !matrix.skip_webui }}
+      env:
+        cache-name: node
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      if: ${{ matrix.rust_build }}
+      env:
+        cache-name: cargo-build-target
+      with:
+        path: aw-server-rust/target
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+
+    # Install fastlane
+    - name: Install fastlane
+      run: |
+        gem install bundler
+        bundle install
+
+    # Set up Rust toolchain
+    - name: Set up Rust toolchain for Android NDK
+      if: ${{ matrix.rust_build }}
+      run: |
+        ANDROID_NDK_HOME=
+        ./aw-server-rust/install-ndk.sh
+
+    # Build webui
+    - name: Build webui
+      if: ${{ !matrix.skip_webui }}
+      run: |
+        make aw-webui
+
+    # Build or fetch aw-server-rust artifacts
+    - name: Build aw-server-rust
+      if: ${{ matrix.rust_build }}
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      run: |
+        make aw-server-rust
+
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      if: ${{ !matrix.rust_build }}
+      with:
+        repo: ActivityWatch/aw-server-rust
+        branch: master
+        workflow: build.yml
+        # Optional, uploaded artifact name,
+        # will download all artifacts if not specified
+        # and extract them in respective subdirectories
+        # https://github.com/actions/download-artifact#download-all-artifacts
+        name: binaries-android
+        path: aw-server-rust/target/
+        # Optional, the status or conclusion of a completed workflow to search for
+        # Can be one of a workflow conculsion::
+        # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+        # Or a workflow status:
+        # "completed", "in_progress", "queued"
+        # Default: "completed"
+        workflow_conclusion: success
+
+    - name: Install aw-server-rust binaries
+      if: ${{ !matrix.rust_build }}
+      # TODO: These are only debug + develop something like "make install" for below
+      run: | 
+        mkdir -p mobile/src/main/jniLibs/arm64-v8a/
+        cp -f ./aw-server-rust/target/aarch64-linux-android/debug/libaw_server.so mobile/src/main/jniLibs/arm64-v8a/libaw_server.so
+        mkdir -p mobile/src/main/jniLibs/armeabi-v7a/
+        cp -f ./aw-server-rust/target/armv7-linux-androideabi/debug/libaw_server.so mobile/src/main/jniLibs/armeabi-v7a/libaw_server.so
+        mkdir -p mobile/src/main/jniLibs/x86/
+        cp -f ./aw-server-rust/target/i686-linux-android/debug/libaw_server.so mobile/src/main/jniLibs/x86/libaw_server.so
+        mkdir -p mobile/src/main/jniLibs/x86_64/
+        cp -f ./aw-server-rust/target/x86_64-linux-android/debug/libaw_server.so mobile/src/main/jniLibs/x86_64/libaw_server.so
+
+    - name: Set version
+      if: startsWith(github.ref, 'refs/tags/v')  # only on runs triggered from tag
+      run: |
+        # Sets versionName, tail used to skip "v" at start of tag name
+        SHORT_VERSION=$(echo "${{ github.ref_name }}" | tail -c +2 -)
+        sed -i "s/versionName \".*\"/versionName \"$SHORT_VERSION\"/g" \
+                mobile/build.gradle
+        bundle exec fastlane update_version
+
+    - name: Load secrets
+      if: env.KEY_ANDROID_JKS != null
+      env:
+        KEY_ANDROID_JKS: ${{ secrets.KEY_ANDROID_JKS }}
+      run: |
+        printf "$KEY_ANDROID_JKS" > android.jks.key
+        cat android.jks.age | age -d -i android.jks.key -o android.jks
+        rm android.jks.key
+
+    - name: Cache Assemble APK
+      env:
+        JKS_STOREPASS: ${{ secrets.KEY_ANDROID_JKS_STOREPASS }}
+        JKS_KEYPASS: ${{ secrets.KEY_ANDROID_JKS_KEYPASS }}
+      run: |
+        # TODO: Add related stuff in .travis.yml
+        # TODO: Allow building even if secrets not set
+        make dist/aw-android.apk
+
+    # # # Test # # reactiveCircus is giving a black screenshot not working 
+    # # # TODO: Take a screenshot of OS to confirm if its Emulator issue or testcode/androidsdk issue - or maybe the emulator is screen off ? 
+    # # # https://github.com/ReactiveCircus/android-emulator-runner
+    # - name: Test Cache
+    #   uses: reactivecircus/android-emulator-runner@v2
+    #   with:
+    #     api-level: ${{ matrix.android_emu_version }}
+    #     arch: x86_64
+    #     profile: Nexus 6
+    #     target: google_apis
+    #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+    #     script: echo Meoooow !
+    # - name: Test
+    #   id: test
+    #   uses: reactivecircus/android-emulator-runner@v2
+    #   with:
+    #     api-level: ${{ matrix.android_emu_version }}
+    #     arch: x86_64
+    #     profile: Nexus 6
+    #     target: google_apis
+    #     emulator-options: -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save
+    #     # Only running specific Instrumentation tests cause others are failing right now. TODO: Fix others
+    #     script: ./gradlew connectedCheck -Pandroid.testInstrumentationRunnerArguments.class=net.activitywatch.android.ScreenshotTest --stacktrace
+
+    # - name: Install recorder and record session
+    #   env:
+    #     SUFFIX: ${{ matrix.android_avd }}-eAPI-${{ matrix.android_emu_version }}-${{ matrix.os }}
+    #   run: |
+    #     brew install ffmpeg
+    #     $ANDROID_HOME/tools/emulator -help-all
+    #     # -logcat *:v
+    #     # $ANDROID_HOME/tools/emulator -port 18725 -verbose -no-audio -gpu swiftshader_indirect -logcat *:v @$MATRIX_AVD &
+    #     ffmpeg -f avfoundation -i 0 -t 120 out$SUFFIX.mov &
+
+    - name: Test App
+      id: test
+      run: |
+        adb logcat -v color &
+        ./gradlew connectedCheck -Pandroid.testInstrumentationRunnerArguments.class=net.activitywatch.android.ScreenshotTest --stacktrace
+        # adb logcat -d
+        adb logcat > mobile/build/logcat.log
+
+    - name: Screenshot
+      if: ${{ success() || steps.test.conclusion == 'failure'}}
+      env:
+        SUFFIX: ${{ matrix.android_avd }}-eAPI-${{ matrix.android_emu_version }}-${{ matrix.os }}
+      run: |
+        sleep 30
+        screencapture pscreenshot$SUFFIX.jpg
+        $ANDROID_HOME/platform-tools/adb exec-out screencap -p > pemulator$SUFFIX.png
+        ls -alh
+  
+    - name: Upload Build artifact
+      if: ${{ success() || steps.test.conclusion == 'failure'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: Build outputs
+        # mobile\build\outputs\connected_android_test_additional_output\debugAndroidTest\connected\Pixel_XL_API_32(AVD) - 12\ScreenshotTest_saveDeviceScreenBitmap.png
+        path: | 
+          mobile/build/reports/*
+          mobile/build/logcat.log
+
+    # - name: Upload video
+    #   if: ${{ success() || steps.test.conclusion == 'failure'}}
+    #   uses: actions/upload-artifact@master
+    #   with:
+    #     name: video
+    #     path: ./*.mov # out.mov
+      
+    - uses: actions/upload-artifact@v3
+      if: ${{ success() || steps.test.conclusion == 'failure'}}
+      with:
+        name: screenshots #.jpg
+        #screenshot.jpg
+        path: |
+          ./*.jpg
+          ./*.png
+          **/mobile/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/*
+          
+    - name: Publish Test Report
+      # # uses: mikepenz/action-junit-report@v3
+      # # # # TODO: Format a little ? or Use some utility to confier GITHUB_STE_SUMMARY.html below into markdown before outputting it into $GITHUB_STEP_SUMMARY?
+      if: ${{ success() || steps.test.conclusion == 'failure'}}
+      # # with:
+      # #   report_paths: '**/build/reports/*Tests/**/*.html' # '**/build/test-results/test/TEST-*.xml'
+      run: |
+        for file in ./mobile/build/reports/androidTests/connected/*.html; do cat $file >> GITHUB_STEP_SUMMARY.html ; done
+        # echo '<style>' >> GITHUB_STEP_SUMMARY.html;for file in ./mobile/build/reports/androidTests/connected/**/*.css; do cat $file >> GITHUB_STEP_SUMMARY.html ; done; echo '</style>' >> GITHUB_STEP_SUMMARY.html;
+        cat GITHUB_STEP_SUMMARY.html >> $GITHUB_STEP_SUMMARY
+
 
   release-fastlane:
     needs: [build]

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,6 @@ clean:
 
 test:
 	bundle exec fastlane test
-	#- ./gradlew clean lint test
-	#- ./gradlew connectedAndroidTest || true
+	# ./gradlew clean lint test
+	# ./gradlew connectedAndroidTest # || true
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.7.20'
     ext.androidXTestVersion = '1.4.0'
     ext.espressoVersion = '3.5.0-rc01'
     ext.extJUnitVersion = '1.1.3'
+    ext.servicesVersion = "1.4.2-rc01"
     repositories {
         google()
         mavenCentral()
@@ -13,7 +14,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,12 @@
 
 buildscript {
     ext.kotlin_version = '1.3.72'
+    ext.androidXTestVersion = '1.4.0'
+    ext.espressoVersion = '3.5.0-rc01'
+    ext.extJUnitVersion = '1.1.3'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -22,7 +25,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -32,6 +32,8 @@ android {
         }
         debug {
             applicationIdSuffix ".debug"
+            jniDebuggable true
+            renderscriptDebuggable true
         }
     }
     compileOptions {
@@ -39,6 +41,9 @@ android {
         targetCompatibility = 1.8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     // Never got this to work...
     //if (project.hasProperty("doNotStrip")) {
     //    packagingOptions {
@@ -68,9 +73,11 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.1'
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    testImplementation "junit:junit:4.13.2"
+    androidTestImplementation "androidx.test.ext:junit-ktx:$extJUnitVersion"
+    androidTestImplementation "androidx.test:runner:$androidXTestVersion"
+    androidTestImplementation "androidx.test:rules:$androidXTestVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 }
 
 // Can be used to build with: ./gradlew cargoBuild

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     ndkVersion "25.0.8775105"
 
     defaultConfig {
         applicationId "net.activitywatch.android"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // Set in CI on tagged commit
         versionName "0.10.0"
@@ -37,8 +37,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = "1.8"
-        targetCompatibility = 1.8
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
     }
 
     kotlinOptions {
@@ -63,15 +63,15 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.annotation:annotation:1.5.0'
 
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.1'
 
     testImplementation "junit:junit:4.13.2"

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,14 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion = '29.0.3'
+    compileSdkVersion 31
     ndkVersion "25.0.8775105"
 
     defaultConfig {
         applicationId "net.activitywatch.android"
-        minSdkVersion 23
-        targetSdkVersion 29
+        minSdkVersion 24
+        targetSdkVersion 31
 
         // Set in CI on tagged commit
         versionName "0.10.0"
@@ -19,6 +18,7 @@ android {
         versionCode 25
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments useTestStorageService: 'true'
 
         // WARNING: Never commit this uncommented!
         packagingOptions {
@@ -44,6 +44,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    namespace 'net.activitywatch.android'
     // Never got this to work...
     //if (project.hasProperty("doNotStrip")) {
     //    packagingOptions {
@@ -78,6 +79,8 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidXTestVersion"
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
+    androidTestUtil "androidx.test.services:test-services:$servicesVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-web:$espressoVersion"
 }
 
 // Can be used to build with: ./gradlew cargoBuild

--- a/mobile/src/androidTest/java/net/activitywatch/android/ExampleInstrumentedTest.kt
+++ b/mobile/src/androidTest/java/net/activitywatch/android/ExampleInstrumentedTest.kt
@@ -21,14 +21,14 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("net.activitywatch.android", appContext.packageName)
     }
 
     @Test
     fun getBuckets() {
         // TODO: Clear test buckets before test
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val ri = RustInterface(appContext)
         val bucketId = "test-${Math.random()}"
         val oldLen = ri.getBucketsJSON().length()
@@ -38,7 +38,7 @@ class ExampleInstrumentedTest {
 
     @Test
     fun createHeartbeat() {
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val ri = RustInterface(appContext)
         val bucketId = "test-${Math.random()}"
         ri.createBucket("""{"id": "$bucketId", "type": "test", "hostname": "test", "client": "test"}""")

--- a/mobile/src/androidTest/java/net/activitywatch/android/ScreenshotTest.kt
+++ b/mobile/src/androidTest/java/net/activitywatch/android/ScreenshotTest.kt
@@ -1,13 +1,17 @@
 package net.activitywatch.android
 
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.core.app.takeScreenshot
 import androidx.test.core.graphics.writeToTestStorage
 import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.rule.GrantPermissionRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestName
 import java.io.IOException
+
 
 /*
  * When this test is executed via gradle managed devices, the saved image files will be stored at
@@ -18,19 +22,26 @@ class ScreenshotTest {
     // a handy JUnit rule that stores the method name, so it can be used to generate unique
     // screenshot files per test method
     @get:Rule
-    var nameRule = TestName()
+    var permissionRule = GrantPermissionRule.grant(android.Manifest.permission.PACKAGE_USAGE_STATS)
 
     @get:Rule
-    val activityScenarioRule = activityScenarioRule<MainActivity>()
+    var nameRule = TestName()
 
+    lateinit var scenario: ActivityScenario<MainActivity>
     /**
      * Captures and saves an image of the entire device screen to storage.
      */
     @Test
     @Throws(IOException::class)
     fun saveDeviceScreenBitmap() {
+
+        //Thread.sleep(100)
+        val intent = Intent(ApplicationProvider.getApplicationContext(), MainActivity::class.java)
+        // TODO: scenarios dont clean up automatically ?
+        scenario = ActivityScenario.launch(intent)
+
         // TODO: Not a good method to sleep, need to properly hook on page load
-        Thread.sleep(2000)
+        Thread.sleep(5000)
         takeScreenshot()
             .writeToTestStorage("${javaClass.simpleName}_${nameRule.methodName}")
     }

--- a/mobile/src/androidTest/java/net/activitywatch/android/ScreenshotTest.kt
+++ b/mobile/src/androidTest/java/net/activitywatch/android/ScreenshotTest.kt
@@ -1,0 +1,37 @@
+package net.activitywatch.android
+
+import androidx.test.core.app.takeScreenshot
+import androidx.test.core.graphics.writeToTestStorage
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.activityScenarioRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestName
+import java.io.IOException
+
+/*
+ * When this test is executed via gradle managed devices, the saved image files will be stored at
+ * build/outputs/managed_device_android_test_additional_output/debugAndroidTest/managedDevice/nexusOneApi30/
+ */
+class ScreenshotTest {
+
+    // a handy JUnit rule that stores the method name, so it can be used to generate unique
+    // screenshot files per test method
+    @get:Rule
+    var nameRule = TestName()
+
+    @get:Rule
+    val activityScenarioRule = activityScenarioRule<MainActivity>()
+
+    /**
+     * Captures and saves an image of the entire device screen to storage.
+     */
+    @Test
+    @Throws(IOException::class)
+    fun saveDeviceScreenBitmap() {
+        // TODO: Not a good method to sleep, need to properly hook on page load
+        Thread.sleep(2000)
+        takeScreenshot()
+            .writeToTestStorage("${javaClass.simpleName}_${nameRule.methodName}")
+    }
+}

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="net.activitywatch.android">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature
         android:name="android.software.leanback"
@@ -32,7 +31,8 @@
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
                 android:configChanges="orientation"
-                android:theme="@style/AppTheme.NoActionBar">
+                android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -48,7 +48,7 @@
         <receiver
                 android:name=".watcher.AlarmReceiver"
                 android:enabled="true"
-            >
+            android:exported="true">
             <intent-filter>
                 <action android:name="net.activitywatch.android.watcher.LOG_DATA"/>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
@@ -56,7 +56,8 @@
         </receiver>
 
         <service android:name=".watcher.ChromeWatcher"
-            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService"/>
             </intent-filter>

--- a/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
+++ b/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
@@ -61,7 +61,7 @@ class WebUIFragment : Fragment() {
                 // TODO: Find way to not show the blinking Android error page
                 Log.e(TAG, "WebView received error: $description")
                 arguments?.let {
-                    myWebView.loadUrl(it.getString(ARG_URL))
+                    it.getString(ARG_URL)?.let { it1 -> myWebView.loadUrl(it1) }
                 }
             }
         }
@@ -76,7 +76,7 @@ class WebUIFragment : Fragment() {
         myWebView.settings.javaScriptEnabled = true
         myWebView.settings.domStorageEnabled = true
         arguments?.let {
-            myWebView.loadUrl(it.getString(ARG_URL))
+            it.getString(ARG_URL)?.let { it1 -> myWebView.loadUrl(it1) }
         }
 
         return view

--- a/mobile/src/main/java/net/activitywatch/android/watcher/ChromeWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/ChromeWatcher.kt
@@ -58,14 +58,14 @@ class ChromeWatcher : AccessibilityService() {
         try {
             if (event != null && event.source != null) {
                 // Get URL
-                val urlBars = event.source.findAccessibilityNodeInfosByViewId("com.android.chrome:id/url_bar")
+                val urlBars = event.source!!.findAccessibilityNodeInfosByViewId("com.android.chrome:id/url_bar")
                 if (urlBars.any()) {
                     val newUrl = "http://" + urlBars[0].text.toString() // TODO: We can't access the URI scheme, so we assume HTTP.
                     onUrl(newUrl)
                 }
 
                 // Get title
-                var webView = findWebView(event.source)
+                var webView = findWebView(event.source!!)
                 if (webView != null) {
                     lastTitle = webView.text.toString()
                     Log.i(TAG, "Title: ${lastTitle}")
@@ -73,7 +73,7 @@ class ChromeWatcher : AccessibilityService() {
             }
         }
         catch(ex : Exception) {
-            Log.e(TAG, ex.message)
+            Log.e(TAG, ex.message!!)
         }
     }
 

--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -1,6 +1,6 @@
 package net.activitywatch.android.watcher
 
-import android.annotation.SuppressLint
+import android.Manifest
 import android.app.AlarmManager
 import android.app.AppOpsManager
 import android.app.PendingIntent
@@ -10,24 +10,20 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.os.AsyncTask
-import android.os.Handler
-import android.os.Looper
-import android.os.SystemClock
+import android.os.*
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
 import net.activitywatch.android.RustInterface
 import net.activitywatch.android.models.Event
 import org.json.JSONObject
-import java.text.SimpleDateFormat
 import org.threeten.bp.DateTimeUtils
 import org.threeten.bp.Instant
-import java.lang.Thread.sleep
 import java.net.URL
 import java.text.ParseException
-
-
+import java.text.SimpleDateFormat
 
 
 class UsageStatsWatcher constructor(val context: Context) {
@@ -40,7 +36,27 @@ class UsageStatsWatcher constructor(val context: Context) {
 
     var lastUpdated: Instant? = null
 
+    // https://stackoverflow.com/a/54839499/4957939
+    fun getUsageStatsPermissionsStatus(context: Context): PermissionStatus? {
+        if (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) return PermissionStatus.CANNOT_BE_GRANTED
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = appOps.checkOpNoThrow(
+            AppOpsManager.OPSTR_GET_USAGE_STATS,
+            Process.myUid(),
+            context.packageName
+        )
+        val granted = if (mode == AppOpsManager.MODE_DEFAULT) context.checkCallingOrSelfPermission(
+            Manifest.permission.PACKAGE_USAGE_STATS
+        ) == PackageManager.PERMISSION_GRANTED else mode == AppOpsManager.MODE_ALLOWED
+        return if (granted) PermissionStatus.GRANTED else PermissionStatus.DENIED
+    }
+
+    enum class PermissionStatus {
+        GRANTED, DENIED, CANNOT_BE_GRANTED
+    }
+
     fun isUsageAllowed(): Boolean {
+
         // https://stackoverflow.com/questions/27215013/check-if-my-application-has-usage-access-enabled
         val applicationInfo: ApplicationInfo = try {
             context.packageManager.getApplicationInfo(context.packageName, 0)
@@ -55,7 +71,8 @@ class UsageStatsWatcher constructor(val context: Context) {
             applicationInfo.uid,
             applicationInfo.packageName
         )
-        return mode == AppOpsManager.MODE_ALLOWED
+        // TODO: Use either of below tests, but the 1st test is not working
+        return mode == AppOpsManager.MODE_ALLOWED || getUsageStatsPermissionsStatus(context) == PermissionStatus.GRANTED
     }
 
     private fun getUSM(): UsageStatsManager? {

--- a/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/UsageStatsWatcher.kt
@@ -1,5 +1,6 @@
 package net.activitywatch.android.watcher
 
+import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.AppOpsManager
 import android.app.PendingIntent
@@ -85,7 +86,7 @@ class UsageStatsWatcher constructor(val context: Context) {
         alarmMgr = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         alarmIntent = Intent(context, AlarmReceiver::class.java).let { intent ->
             intent.action = "net.activitywatch.android.watcher.LOG_DATA"
-            PendingIntent.getBroadcast(context, 0, intent, 0)
+            PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         }
 
         val interval = AlarmManager.INTERVAL_HOUR   // Or if testing: AlarmManager.INTERVAL_HOUR / 60

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -21,8 +21,8 @@
     <string name="button_log_text">Click me to log data!</string>
     <string name="accessibility_service_description">Allows ActivityWatch to read the URL and title from your browser.</string>
 
-    <!-- This is overridden by gradle config -->
-    <string name="versionName">unknown version</string>
+    <!-- This is overridden by gradle config
+    <string name="versionName">unknown version</string>-->
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>


### PR DESCRIPTION
- fixes current state (Dependecies updates + gradle updates + sdk level updates + migration fixes)
- Implementation of e2e test
- Basic CI integration with instrumentation test and present CI failure fixes
- Pulls submodule aw-server-rust to its current master

- Test failes because aw-server-rust dosent start (@ ~steps 5325) (https://github.com/ShootingKing-AM/aw-android/actions/runs/3419657840/jobs/5693454929#step:25:5324) depends on
  - https://github.com/ActivityWatch/aw-server-rust/pull/323 and
  - https://github.com/ActivityWatch/aw-server-rust/pull/324