### PR TITLE
fix: re-enable orientation change, without reloading webview

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -30,8 +30,7 @@
         <activity
                 android:name=".MainActivity"
                 android:label="@string/app_name"
-                android:screenOrientation="portrait"
-                android:configChanges="orientation"
+                android:configChanges="orientation|screenSize"
                 android:theme="@style/AppTheme.NoActionBar"
             android:exported="true">
 

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -84,6 +84,16 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         }
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // Checks the orientation of the screen
+        if (newConfig.orientation === Configuration.ORIENTATION_LANDSCAPE) {
+            Log.i(TAG, "Screen orientation changed to landscape")
+        } else if (newConfig.orientation === Configuration.ORIENTATION_PORTRAIT){
+            Log.i(TAG, "Screen orientation changed to portrait")
+        }
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.main, menu)


### PR DESCRIPTION
Not tested, just generated with gptme.