### PR TITLE
ci: create build-only action for testing in forks

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -1,0 +1,210 @@
+name: "Build only"
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - v*
+  pull_request:
+    branches: [master]
+
+env:
+  NDK_VERSION: "25.2.9519653"
+  NODE_VERSION: "16"
+  JAVA_VERSION: "17"
+
+jobs:
+  build-rust:
+    name: Build aw-server-rust
+    # runs-on: ubuntu-latest
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Set RELEASE
+        run: |
+          echo "RELEASE=${{ startsWith(github.ref_name, 'v') }}" >> $GITHUB_ENV
+
+      - name: Get aw-server-rust submodule commit
+        id: submodule-commit
+        run: |
+          echo "commit=$(git rev-parse HEAD:aw-server-rust)" >> $GITHUB_OUTPUT
+
+      - name: Cache JNI libs
+        uses: actions/cache@v3
+        id: cache-jniLibs
+        env:
+          cache-name: jniLibs
+        with:
+          path: mobile/src/main/jniLibs/
+          key: ${{ env.cache-name }}-release-${{ env.RELEASE }}-ndk-${{ env.NDK_VERSION }}-${{ steps.submodule-commit.outputs.commit }}
+
+      - name: Display structure of downloaded files
+        if: steps.cache-jniLibs.outputs.cache-hit == 'true'
+        run: |
+          pushd mobile/src/main/jniLibs && ls -R && popd
+
+      # Android SDK & NDK
+      - name: Set up Android SDK
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+        uses: android-actions/setup-android@v2
+      - name: Set up Android NDK
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+        run: |
+          sdkmanager "ndk;${{ env.NDK_VERSION }}"
+          ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/${{ env.NDK_VERSION }}"
+          ls $ANDROID_NDK_HOME
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
+
+      # Rust
+      - name: Set up Rust
+        id: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+
+      - name: Set up Rust toolchain for Android NDK
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+        run: |
+          ./aw-server-rust/install-ndk.sh
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+        env:
+          cache-name: cargo-build-target
+        with:
+          path: aw-server-rust/target
+          # key needs to contain cachekey due to https://github.com/ActivityWatch/aw-server-rust/issues/180
+          key: ${{ env.cache-name }}-${{ runner.os }}-release-${{ env.RELEASE }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ env.cache-name }}-${{ runner.os }}-release-${{ env.RELEASE }}-${{ steps.toolchain.outputs.cachekey }}-
+
+      - name: Build aw-server-rust
+        if: steps.cache-jniLibs.outputs.cache-hit != 'true'
+        run: |
+          make aw-server-rust
+
+      - name: Check that jniLibs present
+        run: |
+          test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
+
+  # This needs to be a seperate job since fastlane update_version,
+  # fails if run concurrently (such as in build apk/aab matrix),
+  # thus we need to run it once and and reuse the results.
+  # https://github.com/fastlane/fastlane/issues/13689#issuecomment-439217502
+  get-versionCode:
+    name: Get latest versionCode
+    runs-on: ubuntu-latest
+    outputs:
+      versionCode: ${{ steps.versionCode.outputs.versionCode }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Output versionCode
+        id: versionCode
+        run: |
+          cat mobile/build.gradle | grep versionCode | sed 's/.*\s\([0-9]*\)$/versionCode=\1/' >> "$GITHUB_OUTPUT"
+
+  build-apk:
+    name: Build ${{ matrix.type }}
+    runs-on: ubuntu-latest
+    needs: [build-rust, get-versionCode]
+    strategy:
+      fail-fast: true
+      matrix:
+        type: ["apk", "aab"]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - uses: ActivityWatch/check-version-format-action@v2
+        id: version
+        with:
+          prefix: "v"
+
+      - name: Echo version
+        run: |
+          echo "${{ steps.version.outputs.full }} (stable: ${{ steps.version.outputs.is_stable }})"
+
+      - name: Set RELEASE
+        run: |
+          # Build in release mode if on a tag/release (longer build times)
+          echo "RELEASE=${{ startsWith(github.ref_name, 'v') }}" >> $GITHUB_ENV
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      # Android SDK & NDK
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Set up Android NDK
+        run: |
+          sdkmanager "ndk;${{ env.NDK_VERSION }}"
+          ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/${{ env.NDK_VERSION }}"
+          ls $ANDROID_NDK_HOME
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
+
+      - name: Get aw-server-rust submodule commit
+        id: submodule-commit
+        run: |
+          echo "commit=$(git rev-parse HEAD:aw-server-rust)" >> $GITHUB_OUTPUT
+
+      # Restores jniLibs from cache
+      # `actions/cache/restore` only restores, without saving back in a post-hook
+      - uses: actions/cache/restore@v3
+        id: cache-jniLibs
+        env:
+          cache-name: jniLibs
+        with:
+          path: mobile/src/main/jniLibs/
+          key: ${{ env.cache-name }}-release-${{ env.RELEASE }}-ndk-${{ env.NDK_VERSION }}-${{ steps.submodule-commit.outputs.commit }}
+          fail-on-cache-miss: true
+
+      - name: Check that jniLibs present
+        run: |
+          test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
+
+      - name: Set versionName
+        if: startsWith(github.ref, 'refs/tags/v') # only on runs triggered from tag
+        run: |
+          # Sets versionName, tail used to skip "v" at start of tag name
+          SHORT_VERSION=$(echo "${{ github.ref_name }}" | tail -c +2 -)
+          sed -i "s/versionName \".*\"/versionName \"$SHORT_VERSION\"/g" \
+                  mobile/build.gradle
+
+      - name: Set versionCode
+        run: |
+          # Sets versionCode
+          sed -i "s/versionCode .*/versionCode ${{needs.get-versionCode.outputs.versionCode}}/" \
+                  mobile/build.gradle
+
+      - uses: adnsio/setup-age-action@v1.2.0
+      - name: Load Android secrets
+        if: env.KEY_ANDROID_JKS != null
+        env:
+          KEY_ANDROID_JKS: ${{ secrets.KEY_ANDROID_JKS }}
+        run: |
+          printf "$KEY_ANDROID_JKS" > android.jks.key
+          cat android.jks.age | age -d -i android.jks.key -o android.jks
+          rm android.jks.key
+
+      - name: Assemble
+        env:
+          JKS_STOREPASS: ${{ secrets.KEY_ANDROID_JKS_STOREPASS }}
+          JKS_KEYPASS: ${{ secrets.KEY_ANDROID_JKS_KEYPASS }}
+        run: |
+          make dist/aw-android.${{ matrix.type }}
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: aw-android.${{ matrix.type }}
+          path: dist/aw-android*.${{ matrix.type }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `build-only.yml` workflow for building `aw-server-rust` and Android APK/AAB with caching and artifact upload.
> 
>   - **Workflow Setup**:
>     - New workflow `build-only.yml` for building `aw-server-rust` and Android APK/AAB.
>     - Triggered on `master` branch pushes, pull requests, and tags starting with 'v'.
>   - **Jobs**:
>     - `build-rust`: Builds `aw-server-rust` on macOS, caches JNI libs and Rust cargo builds.
>     - `get-versionCode`: Retrieves version code from `mobile/build.gradle`.
>     - `build-apk`: Builds Android APK/AAB, sets up environments, caches JNI libs.
>   - **Caching and Environment**:
>     - Caches JNI libraries and Rust cargo builds.
>     - Sets up Android SDK, NDK, Rust, and Java environments.
>   - **Artifact Handling**:
>     - Uploads built APK/AAB artifacts using `actions/upload-artifact@v4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-android&utm_source=github&utm_medium=referral)<sup> for 10efdf80c98a1bda8648f598b236545f896bd4d3. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->