### PR TITLE
fix(release): require committed versionName for tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,13 +219,20 @@ jobs:
       run: |
         test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
 
-    - name: Set versionName
+    - name: Verify versionName matches tag
       if: startsWith(github.ref, 'refs/tags/v')  # only on runs triggered from tag
       run: |
-        # Sets versionName, tail used to skip "v" at start of tag name
-        SHORT_VERSION=$(echo "${{ github.ref_name }}" | tail -c +2 -)
-        sed -i "s/versionName \".*\"/versionName \"$SHORT_VERSION\"/g" \
-                mobile/build.gradle
+        SHORT_VERSION="${GITHUB_REF_NAME#v}"
+        COMMITTED_VERSION=$(sed -n -E "s/^[[:space:]]*versionName[[:space:]]+['\"]([^'\"]+)['\"].*/\\1/p" mobile/build.gradle)
+        if [ -z "$COMMITTED_VERSION" ]; then
+          echo "Failed to parse versionName from mobile/build.gradle."
+          exit 1
+        fi
+        if [ "$COMMITTED_VERSION" != "$SHORT_VERSION" ]; then
+          echo "mobile/build.gradle versionName must match the release tag."
+          echo "tag=$SHORT_VERSION committed=$COMMITTED_VERSION"
+          exit 1
+        fi
 
     - name: Set versionCode
       run: |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ Once both aw-server-rust and aw-webui is built, you can build the Android app as
 
 ### Making a release
 
-To make a release, make a signed tag and push it to GitHub:
+Before tagging, update `mobile/build.gradle` so `versionName` matches the
+release you are about to cut. The release workflow verifies the committed
+`versionName` instead of patching it after checkout, which keeps tagged source,
+GitHub release builds, and F-Droid builds on the same version.
+
+Then make a signed tag and push it to GitHub:
 
 ```sh
 git tag -s v0.1.0

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -10,9 +10,8 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
 
-        // Set in CI on tagged commit
-        // FIXME: should be set before tagging, so that F-droid picks it up correctly
-        //        https://gitlab.com/fdroid/fdroiddata/-/merge_requests/11786?commit_id=d2cedcbe3d26db59378d582a8cf952af16b6407f#note_1966750559
+        // Keep versionName committed in source so tagged builds and F-Droid agree.
+        // Tag workflows verify it matches refs/tags/v* instead of rewriting the checkout.
         versionName "0.12.1"
 
         // Set in CI by `bundle exec fastlane update_version`


### PR DESCRIPTION
## Summary
- stop rewriting `mobile/build.gradle` `versionName` during tag builds
- fail tag workflows when the committed `versionName` does not match the `v*` tag
- document the pre-tag release step so tagged source, GitHub releases, and F-Droid builds stay aligned

Closes #24.