### PR TITLE
feat(auth): bootstrap android dashboard token

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
+++ b/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
@@ -42,13 +42,13 @@ internal fun buildDashboardUrl(baseUrl: String, apiKey: String?): String {
     )
 
     val normalizedPath = parsedUrl.path?.takeIf { it.isNotEmpty() } ?: "/"
-    return URI(
-        parsedUrl.scheme,
-        parsedUrl.authority,
-        normalizedPath,
-        queryParts.joinToString("&"),
-        parsedUrl.fragment,
-    ).toASCIIString()
+    val rawQuery = queryParts.joinToString("&")
+    val rawFragment = parsedUrl.rawFragment
+    return buildString {
+        append(parsedUrl.scheme).append("://").append(parsedUrl.authority)
+        append(normalizedPath).append("?").append(rawQuery)
+        if (rawFragment != null) append("#").append(rawFragment)
+    }
 }
 
 internal fun extractApiKey(config: String): String? {
@@ -136,5 +136,5 @@ private fun escapeTomlString(value: String): String {
 
 private fun parseSectionName(line: String): String? {
     val match = sectionHeaderPattern.matchEntire(line) ?: return null
-    return match.groupValues[1].trim().lowercase()
+    return match.groupValues[1].trim().removeSurrounding("\"")
 }

--- a/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
+++ b/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
@@ -1,0 +1,140 @@
+package net.activitywatch.android
+
+import android.content.Context
+import java.io.File
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+private const val CONFIG_FILE_NAME = "config.toml"
+private const val AUTH_SECTION = "auth"
+
+private val sectionHeaderPattern = Regex("""^\s*\[([^\]]+)]\s*(?:#.*)?$""")
+private val apiKeyPattern = Regex("""^\s*api_key\s*=\s*(['"])(.*?)\1\s*(?:#.*)?$""")
+
+fun ensureDashboardApiKey(context: Context): String {
+    val configFile = File(context.filesDir, CONFIG_FILE_NAME)
+    val currentConfig = if (configFile.isFile) configFile.readText() else ""
+    val existingApiKey = extractApiKey(currentConfig)
+    if (existingApiKey != null) {
+        return existingApiKey
+    }
+
+    val generatedApiKey = UUID.randomUUID().toString()
+    configFile.writeText(upsertApiKey(currentConfig, generatedApiKey))
+    return generatedApiKey
+}
+
+internal fun buildDashboardUrl(baseUrl: String, apiKey: String?): String {
+    val normalizedApiKey = apiKey?.trim().orEmpty()
+    if (normalizedApiKey.isEmpty()) {
+        return baseUrl
+    }
+    val parsedUrl = URI(baseUrl)
+    val queryParts = mutableListOf<String>()
+
+    if (!parsedUrl.rawQuery.isNullOrBlank()) {
+        queryParts.add(parsedUrl.rawQuery)
+    }
+    queryParts.add(
+        "token=${URLEncoder.encode(normalizedApiKey, StandardCharsets.UTF_8.name())}"
+    )
+
+    val normalizedPath = parsedUrl.path?.takeIf { it.isNotEmpty() } ?: "/"
+    return URI(
+        parsedUrl.scheme,
+        parsedUrl.authority,
+        normalizedPath,
+        queryParts.joinToString("&"),
+        parsedUrl.fragment,
+    ).toASCIIString()
+}
+
+internal fun extractApiKey(config: String): String? {
+    var inAuthSection = false
+
+    for (line in config.lineSequence()) {
+        val trimmed = line.trim()
+        if (trimmed.startsWith("#")) {
+            continue
+        }
+
+        val sectionName = parseSectionName(trimmed)
+        if (sectionName != null) {
+            inAuthSection = sectionName == AUTH_SECTION
+            continue
+        }
+
+        if (!inAuthSection) {
+            continue
+        }
+
+        val apiKeyMatch = apiKeyPattern.matchEntire(trimmed) ?: continue
+        val apiKey = apiKeyMatch.groupValues[2].trim()
+        if (apiKey.isNotEmpty()) {
+            return apiKey
+        }
+    }
+
+    return null
+}
+
+internal fun upsertApiKey(config: String, apiKey: String): String {
+    val escapedApiKey = escapeTomlString(apiKey)
+    val renderedApiKey = """api_key = "$escapedApiKey""""
+    val result = mutableListOf<String>()
+    var inAuthSection = false
+    var insertedApiKey = false
+
+    for (line in config.lineSequence()) {
+        val trimmed = line.trim()
+        val sectionName = parseSectionName(trimmed)
+
+        if (sectionName != null) {
+            if (inAuthSection && !insertedApiKey) {
+                result.add(renderedApiKey)
+                insertedApiKey = true
+            }
+            inAuthSection = sectionName == AUTH_SECTION
+            result.add(line)
+            continue
+        }
+
+        if (inAuthSection && apiKeyPattern.matchEntire(trimmed) != null) {
+            if (!insertedApiKey) {
+                result.add(renderedApiKey)
+                insertedApiKey = true
+            }
+            continue
+        }
+
+        result.add(line)
+    }
+
+    if (inAuthSection && !insertedApiKey) {
+        result.add(renderedApiKey)
+        insertedApiKey = true
+    }
+
+    if (!insertedApiKey) {
+        if (result.isNotEmpty() && result.last().isNotBlank()) {
+            result.add("")
+        }
+        result.add("[auth]")
+        result.add(renderedApiKey)
+    }
+
+    return result.joinToString("\n").let { rendered ->
+        if (rendered.endsWith("\n")) rendered else "$rendered\n"
+    }
+}
+
+private fun escapeTomlString(value: String): String {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"")
+}
+
+private fun parseSectionName(line: String): String? {
+    val match = sectionHeaderPattern.matchEntire(line) ?: return null
+    return match.groupValues[1].trim().lowercase()
+}

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -27,11 +27,20 @@ const val baseURL = "http://127.0.0.1:5600"
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener, WebUIFragment.OnFragmentInteractionListener {
 
     private lateinit var binding: ActivityMainBinding
+    private lateinit var dashboardApiKey: String
 
     val version: String
         get() {
             return packageManager.getPackageInfo(packageName, 0).versionName
         }
+
+    private fun authenticatedUrl(url: String = baseURL): String {
+        return buildDashboardUrl(url, dashboardApiKey)
+    }
+
+    private fun openDashboardInBrowser(url: String = baseURL) {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(authenticatedUrl(url))))
+    }
 
     override fun onFragmentInteraction(item: Uri) {
         Log.w(TAG, "URI onInteraction listener not implemented")
@@ -61,6 +70,8 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         binding.navView.setNavigationItemSelectedListener(this)
 
+        // Ensure API key exists in config before the server starts so it picks it up at init.
+        dashboardApiKey = ensureDashboardApiKey(this)
         // Start background service to keep server and sync running
         val serviceIntent = Intent(this, BackgroundService::class.java)
         startForegroundService(serviceIntent)
@@ -68,7 +79,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         if (savedInstanceState != null) {
             return
         }
-        val firstFragment = WebUIFragment.newInstance(baseURL)
+        val firstFragment = WebUIFragment.newInstance(authenticatedUrl())
         supportFragmentManager.beginTransaction()
             .add(R.id.fragment_container, firstFragment).commit()
 
@@ -125,19 +136,18 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
             R.id.nav_activity -> {
                 fragmentClass = WebUIFragment::class.java
-                url = "$baseURL/#/activity/unknown/"
+                url = authenticatedUrl("$baseURL/#/activity/unknown/")
             }
             R.id.nav_buckets -> {
                 fragmentClass = WebUIFragment::class.java
-                url = "$baseURL/#/buckets/"
+                url = authenticatedUrl("$baseURL/#/buckets/")
             }
             R.id.nav_settings -> {
                 fragmentClass = WebUIFragment::class.java
-                url = "$baseURL/#/settings/"
+                url = authenticatedUrl("$baseURL/#/settings/")
             }
             R.id.nav_share -> {
-                Snackbar.make(binding.coordinatorLayout, "The share button was clicked, but it's not yet implemented!", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
+                openDashboardInBrowser()
             }
             R.id.nav_send -> {
                 Snackbar.make(binding.coordinatorLayout, "The send button was clicked, but it's not yet implemented!", Snackbar.LENGTH_LONG)

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package net.activitywatch.android
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -39,7 +40,11 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     }
 
     private fun openDashboardInBrowser(url: String = baseURL) {
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(authenticatedUrl(url))))
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(authenticatedUrl(url))))
+        } catch (e: ActivityNotFoundException) {
+            Snackbar.make(binding.root, R.string.no_browser_found, Snackbar.LENGTH_SHORT).show()
+        }
     }
 
     override fun onFragmentInteraction(item: Uri) {

--- a/mobile/src/main/res/menu/activity_main_drawer.xml
+++ b/mobile/src/main/res/menu/activity_main_drawer.xml
@@ -28,7 +28,7 @@
                 <item
                         android:id="@+id/nav_share"
                         android:icon="@drawable/ic_menu_share"
-                        android:title="Share"/>
+                        android:title="@string/open_in_browser"/>
                 <item
                         android:id="@+id/nav_send"
                         android:icon="@drawable/ic_menu_send"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="nav_header_subtitle">v0.1.0</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
+    <string name="open_in_browser">Open in browser</string>
     <string name="title_activity_buckets">BucketsActivity</string>
     <string name="welcome_title_text">Welcome, early user!</string>
     <string name="welcome_text">

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -30,4 +30,7 @@
 
     <!-- Widget strings -->
     <string name="widget_category_time_description">Shows today\'s screen time and top categories</string>
+
+    <!-- Auth strings -->
+    <string name="no_browser_found">No browser app available to open this URL</string>
 </resources>

--- a/mobile/src/test/java/net/activitywatch/android/DashboardAuthTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/DashboardAuthTest.kt
@@ -1,0 +1,72 @@
+package net.activitywatch.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DashboardAuthTest {
+    @Test
+    fun buildDashboardUrl_skipsTokenWhenAuthDisabled() {
+        assertEquals("http://127.0.0.1:5600", buildDashboardUrl(baseURL, null))
+    }
+
+    @Test
+    fun buildDashboardUrl_appendsEncodedTokenBeforeHashRoute() {
+        assertEquals(
+            "http://127.0.0.1:5600/?token=secret%2B+%2F%3F%3D%26#/activity/unknown/",
+            buildDashboardUrl(
+                "$baseURL/#/activity/unknown/",
+                "secret+ /?=&",
+            ),
+        )
+    }
+
+    @Test
+    fun extractApiKey_readsExistingAuthSection() {
+        val config = """
+            address = "127.0.0.1"
+
+            [auth]
+            api_key = "existing-token"
+        """.trimIndent()
+
+        assertEquals("existing-token", extractApiKey(config))
+    }
+
+    @Test
+    fun extractApiKey_ignoresCommentedDefaults() {
+        val config = """
+            ### DEFAULT SETTINGS ###
+            #[auth]
+            #api_key = "commented"
+        """.trimIndent()
+
+        assertNull(extractApiKey(config))
+    }
+
+    @Test
+    fun upsertApiKey_appendsAuthSectionWhenMissing() {
+        val updated = upsertApiKey("address = \"127.0.0.1\"\n", "generated-token")
+
+        assertEquals(
+            "address = \"127.0.0.1\"\n\n[auth]\napi_key = \"generated-token\"\n",
+            updated,
+        )
+    }
+
+    @Test
+    fun upsertApiKey_replacesExistingValueWithoutDroppingOtherSections() {
+        val config = """
+            [auth]
+            api_key = "old-token"
+
+            [custom_static]
+            test = "/tmp/static"
+        """.trimIndent()
+
+        assertEquals(
+            "[auth]\napi_key = \"new-token\"\n\n[custom_static]\ntest = \"/tmp/static\"\n",
+            upsertApiKey(config, "new-token"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- bump the embedded aw-server-rust submodule to the Android auth-capable commit from ActivityWatch/aw-server-rust#608
- ensure Android writes a non-empty [auth].api_key into filesDir/config.toml before starting the embedded server
- append ?token=... to the embedded WebView URL and add a real Open in browser action for the external browser path
- add JVM unit tests for token URL building plus auth-config extraction/upsert behavior

## Why
This is the app-side slice of ActivityWatch/aw-android#145 now that the server-side Android config prerequisite merged in ActivityWatch/aw-server-rust#608.

## Testing
- git diff --check
- Local Gradle/unit-test execution is still blocked in the current container because there is no Java/Android SDK toolchain here
- GitHub Actions on this draft PR should exercise the Android build/test matrix