### PR TITLE
fix(ci): skip Fastlane versionCode lookup for PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,16 +99,23 @@ jobs:
         submodules: 'recursive'
 
 
-    # Ruby & Fastlane
+    # Ruby & Fastlane — only needed for non-PR builds.
+    # PRs (especially from forks) don't have access to KEY_FASTLANE_API, so
+    # they fall through to the Output step which reads the current versionCode
+    # directly from mobile/build.gradle.  This is fine for build verification;
+    # the real Play Store versionCode is only needed for release builds.
     # version set by .ruby-version
     - name: Set up Ruby and install fastlane
+      if: github.event_name != 'pull_request'
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
 
     # Needed for `fastlane update_version`
     - uses: adnsio/setup-age-action@v1.2.0
+      if: github.event_name != 'pull_request'
     - name: Load Fastlane secrets
+      if: github.event_name != 'pull_request'
       env:
         KEY_FASTLANE_API: ${{ secrets.KEY_FASTLANE_API }}
       run: |
@@ -121,6 +128,7 @@ jobs:
     # Retry this, in case there are concurrent jobs, which may lead to the error:
     #   "Google Api Error: Invalid request - This Edit has been deleted."
     - name: Update versionCode
+      if: github.event_name != 'pull_request'
       uses: Wandalen/wretry.action@master
       with:
         command: bundle exec fastlane update_version


### PR DESCRIPTION
## Problem

The `get-versionCode` CI job requires the `KEY_FASTLANE_API` secret to decrypt the Google Play API key. This secret is not available to fork PRs (GitHub's security model), so the job fails at the `Load Fastlane secrets` step. This blocks CI for all pull requests from forks.

## Fix

Add `if: github.event_name != 'pull_request'` to all Fastlane-dependent steps:
- `Set up Ruby and install fastlane`
- `adnsio/setup-age-action`
- `Load Fastlane secrets`
- `Update versionCode`

For PR builds, those steps are skipped. The job falls through to the `Output versionCode` step, which reads the current versionCode directly from `mobile/build.gradle`. This is already the approach used by `build-only.yml`.

The real Play Store versionCode increment only matters for release builds (master branch and tag pushes), which still run the full Fastlane flow.

## Verification

- PR builds: `get-versionCode` skips Fastlane, reads `versionCode 34` (or whatever's in build.gradle) and passes
- Master/tag builds: unchanged — still runs `bundle exec fastlane update_version`

Closes the CI blocker reported in ActivityWatch/aw-android#139 and noted in ActivityWatch/aw-android#156.