### PR TITLE
fix(webui): keep embedded ActivityWatch URLs inside WebView

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
+++ b/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
@@ -37,8 +37,9 @@ internal fun isEmbeddedActivityWatchUrl(url: String): Boolean {
         return false
     }
 
+    // java.net.URI.getHost() returns IPv6 addresses with brackets, e.g. "[::1]"
     return when (uri.host?.lowercase()) {
-        "localhost", "127.0.0.1", "::1" -> true
+        "localhost", "127.0.0.1", "[::1]" -> true
         else -> false
     }
 }

--- a/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
+++ b/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
@@ -19,10 +19,29 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebViewClient
 import net.activitywatch.android.R
 import java.lang.Thread.sleep
+import java.net.URI
 
 private const val TAG = "WebUI"
 
 private const val ARG_URL = "url"
+
+// The embedded server lives on loopback, so keep those navigations inside the app WebView.
+internal fun isEmbeddedActivityWatchUrl(url: String): Boolean {
+    val uri = try {
+        URI(url)
+    } catch (_: Exception) {
+        return false
+    }
+
+    if (uri.scheme != "http" && uri.scheme != "https") {
+        return false
+    }
+
+    return when (uri.host?.lowercase()) {
+        "localhost", "127.0.0.1", "::1" -> true
+        else -> false
+    }
+}
 
 /**
  * A simple [Fragment] subclass.
@@ -74,7 +93,7 @@ class WebUIFragment : Fragment() {
                 val url = request?.url.toString()
                 if (URLUtil.isNetworkUrl(url)) {
                     if (url.startsWith("http://") || url.startsWith("https://")) {
-                        if (!url.contains("//localhost:")) {
+                        if (!isEmbeddedActivityWatchUrl(url)) {
                             // Open the URL in an external browser
                             val i = Intent(Intent.ACTION_VIEW, Uri.parse(url))
                             startActivity(i)

--- a/mobile/src/test/java/net/activitywatch/android/fragments/WebUIFragmentTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/fragments/WebUIFragmentTest.kt
@@ -7,9 +7,16 @@ import org.junit.Test
 class WebUIFragmentTest {
     @Test
     fun `treats local embedded server hosts as internal`() {
+        // http variants
         assertTrue(isEmbeddedActivityWatchUrl("http://127.0.0.1:5600/#/settings/"))
         assertTrue(isEmbeddedActivityWatchUrl("http://localhost:5600/#/settings/"))
         assertTrue(isEmbeddedActivityWatchUrl("http://[::1]:5600/#/settings/"))
+        // https variants (function explicitly allows both schemes)
+        assertTrue(isEmbeddedActivityWatchUrl("https://127.0.0.1:5600/"))
+        assertTrue(isEmbeddedActivityWatchUrl("https://localhost:5600/"))
+        assertTrue(isEmbeddedActivityWatchUrl("https://[::1]:5600/"))
+        // no-port case
+        assertTrue(isEmbeddedActivityWatchUrl("http://localhost/"))
     }
 
     @Test

--- a/mobile/src/test/java/net/activitywatch/android/fragments/WebUIFragmentTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/fragments/WebUIFragmentTest.kt
@@ -1,0 +1,21 @@
+package net.activitywatch.android.fragments
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WebUIFragmentTest {
+    @Test
+    fun `treats local embedded server hosts as internal`() {
+        assertTrue(isEmbeddedActivityWatchUrl("http://127.0.0.1:5600/#/settings/"))
+        assertTrue(isEmbeddedActivityWatchUrl("http://localhost:5600/#/settings/"))
+        assertTrue(isEmbeddedActivityWatchUrl("http://[::1]:5600/#/settings/"))
+    }
+
+    @Test
+    fun `treats non-loopback hosts as external`() {
+        assertFalse(isEmbeddedActivityWatchUrl("https://activitywatch.net"))
+        assertFalse(isEmbeddedActivityWatchUrl("http://192.168.1.10:5600"))
+        assertFalse(isEmbeddedActivityWatchUrl("not a url"))
+    }
+}


### PR DESCRIPTION
## Summary
- keep loopback ActivityWatch URLs inside the embedded WebView instead of opening them in the external browser
- treat both `127.0.0.1` and `localhost` as internal embedded-server hosts
- add a small unit test for the host-classification helper

## Why
The Android app serves the embedded UI from `http://127.0.0.1:5600`, but the current WebView override only whitelists `localhost`. That means internal navigations can get kicked out to the external browser, which uses different web storage than the in-app WebView. That matches the `settings saved but not applied` symptom from #153.

## Testing
- added `WebUIFragmentTest` coverage for internal vs external host handling
- could not run Gradle tests in this environment because `java` is not installed on Bob's VM

Refs #153