### PR TITLE
fix(ci): pin Rust to 1.79.0 to avoid E0282 in time crate on 1.80+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,9 @@ jobs:
     # Rust
     - name: Set up Rust
       id: toolchain
-      uses: dtolnay/rust-toolchain@stable
+      # Pin to 1.79.0: aw-server-rust@dc70318 uses `time` crate which fails to compile
+      # on Rust 1.80+ due to tightened type inference (E0282 in Box<_> expressions).
+      uses: dtolnay/rust-toolchain@1.79.0
       if: steps.cache-jniLibs.outputs.cache-hit != 'true'
 
     - name: Set up Rust toolchain for Android NDK


### PR DESCRIPTION
## Summary

- `aw-server-rust@dc70318` depends on an older version of the `time` crate that fails to compile on Rust 1.80+ due to tightened type inference (`E0282: type annotations needed for Box<_>`)
- Master CI has been failing on every push since Rust stable moved to 1.80+
- Pin `dtolnay/rust-toolchain` to `1.79.0` in the `Build aw-server-rust` job until aw-server-rust updates its dependencies

## Error (from master CI run 26290684290)

```
error[E0282]: type annotations needed for `Box<_>`
error: could not compile `time` (lib) due to 1 previous error
```

## Fix

Change `dtolnay/rust-toolchain@stable` → `dtolnay/rust-toolchain@1.79.0` with a comment explaining the pin. Unpin once `aw-server-rust` updates its `time` crate dependency.

## Test plan

- [ ] CI Build aw-server-rust job passes with pinned Rust 1.79.0