### PR TITLE
ci: update test job runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build-rust]
     env:
       SUPPLY_TRACK: production   # used by fastlane to determine track to publish to


### PR DESCRIPTION
## Summary

- `ubuntu-20.04` GitHub-hosted runners are no longer available, causing the **Test** job to wait indefinitely for a runner that never picks it up
- Updated to `ubuntu-22.04` (current LTS, full runner availability)

## Root Cause

Erik noticed in #156 that the Test CI job was stuck at "Waiting for a runner to pick up this job..." — the `ubuntu-20.04` runner image has been removed by GitHub. The test job at line 232 of `build.yml` was the culprit.

## Note

There are also several deprecated action versions in the workflow (`actions/checkout@v2`, `actions/setup-java@v1`, `actions/upload-artifact@v3`, `actions/download-artifact@v3`). Those were already being tracked separately and are a follow-up concern — this PR only fixes the blocking runner issue.