### PR TITLE
Fix Rust initialize JNI return type

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -38,7 +38,7 @@ class RustInterface constructor(context: Context? = null) {
         var serverStarted = false
     }
 
-    private external fun initialize(): String
+    private external fun initialize()
     private external fun greeting(pattern: String): String
     private external fun startServer()
     private external fun setDataDir(path: String)


### PR DESCRIPTION
Fixes a JNI return type mismatch for `initialize`. The native `initialize` method does not return a value, so the Kotlin external declaration should use `Unit` instead of `String`.

Verification:
- Reproduced before this fix on the Pixel 9 emulator, Android 16 / x86_64: launching the pre-fix debug APK crashes immediately after `aw-server-rust: Initializing aw-server-rust...` with `Fatal signal 11 (SIGSEGV)`. The native backtrace includes `art::CheckReferenceResult`, `art::GenericJniMethodEnd`, and `net.activitywatch.android.RustInterface.<init>`.
- Verified the fixed debug APK on the same emulator: the app launches, `aw-server-rust` starts at `127.0.0.1:5600`, and no `AndroidRuntime`, `libc`, or `DEBUG` fatal crash logs are emitted during startup.
- `./gradlew.bat :mobile:testDebugUnitTest` passed with Temurin 17.

Related issue:
- Related to #124, which reports an instant startup crash with `JNI DETECTED ERROR IN APPLICATION: use of invalid jobject` and `JniMethodEndWithReferenceHandleResult`.