### PR TITLE
fix(ci): upgrade android-actions/setup-android from v2 to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,12 +349,25 @@ jobs:
     # # # Below code is majorly from https://github.com/actions/runner-images/issues/6152#issuecomment-1243718140
     - name: Create Android emulator
       run: |
+        # Pin AVD home so avdmanager and emulator agree on the location.
+        # android-actions/setup-android@v3 no longer exports ANDROID_SDK_HOME
+        # (it was deprecated by Google), so we set ANDROID_AVD_HOME explicitly
+        # and persist it for subsequent steps via GITHUB_ENV.
+        AVD_HOME="$HOME/.android/avd"
+        mkdir -p "$AVD_HOME"
+        echo "ANDROID_AVD_HOME=$AVD_HOME" >> "$GITHUB_ENV"
+        export ANDROID_AVD_HOME="$AVD_HOME"
+
         # Install AVD files
         echo "y" | sdkmanager --install 'system-images;android-'$MATRIX_E_SDK';default;x86_64'
         echo "y" | sdkmanager --licenses
 
         # Create emulator
         avdmanager create avd -n $MATRIX_AVD -d pixel --package 'system-images;android-'$MATRIX_E_SDK';default;x86_64'
+
+        # Verify AVD was created before proceeding
+        echo "AVDs in $ANDROID_AVD_HOME:"
+        ls -la "$ANDROID_AVD_HOME/" 2>/dev/null || echo "WARNING: AVD directory empty after creation!"
         $ANDROID_HOME/emulator/emulator -list-avds
         if false; then
         emulator_config=~/.android/avd/$MATRIX_AVD.avd/config.ini

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     # Android SDK & NDK
     - name: Set up Android SDK
       if: steps.cache-jniLibs.outputs.cache-hit != 'true'
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
     - name: Set up Android NDK
       if: steps.cache-jniLibs.outputs.cache-hit != 'true'
       run: |
@@ -196,7 +196,7 @@ jobs:
 
     # Android SDK & NDK
     - name: Set up Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
     - name: Set up Android NDK
       run: |
         sdkmanager "ndk;${{ env.NDK_VERSION }}"
@@ -281,7 +281,7 @@ jobs:
 
     # Android SDK & NDK (NDK required at Gradle configuration time even for JVM unit tests)
     - name: Set up Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
     - name: Set up Android NDK
       run: |
         sdkmanager "ndk;${{ env.NDK_VERSION }}"
@@ -344,7 +344,7 @@ jobs:
       run: brew install intel-haxm
 
     - name: Set up Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
 
     # # # Below code is majorly from https://github.com/actions/runner-images/issues/6152#issuecomment-1243718140
     - name: Create Android emulator


### PR DESCRIPTION
## Summary

- Upgrades all 4 instances of `android-actions/setup-android@v2` to `@v3` in `.github/workflows/build.yml`

## Root Cause

The `build-apk` job (running on Ubicloud Ubuntu 24.04 runners) has been failing since ~10:30 UTC today at the "Set up Android SDK" step with errors about unaccepted Google SDK licenses (GoogleTV and Android XR):

```
Warning: License for package Android SDK Platform 34 not accepted.
Warning: License for package Google TV for Android (Google TV system image 34) not accepted.
Warning: License for package Android XR (Android XR Emulator system image Baklava) not accepted.
```

`@v3` of `android-actions/setup-android` properly handles the acceptance of new SDK component licenses that were added since `@v2`.

The `test` job wasn't failing because it runs on `ubuntu-22.04` which has Android SDK pre-installed with the old licenses pre-accepted.

## Test Plan

- [ ] CI passes on all 4 jobs: `build-apk`, `build-aab`, `test`, `test-e2e`