### PR TITLE
fix(migration): handle plain-text success response from migrateHostname JNI

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -64,19 +64,23 @@ class BackgroundService : Service() {
                 val hostname = rustInterface.getDeviceName(this@BackgroundService)
                 val result = rustInterface.migrateHostname(hostname)
                 Log.i(TAG, "Hostname migration result: $result")
-                // Conservative defaults: treat ambiguous responses (non-JSON or absent "success" key)
-                // as failures so the migration is retried on the next start rather than being
-                // permanently silenced before the server was actually ready.
-                val migrationSucceeded = try {
-                    JSONObject(result).optBoolean("success", false)
-                } catch (e: JSONException) {
-                    Log.w(TAG, "Migration result was not valid JSON; will retry on next start")
+                // The native migrateHostname() returns a plain-text success string
+                // ("Migrated hostname for N bucket(s)") or a JSON error object
+                // ({"error": "..."}).  Treat the plain-text prefix as success; only
+                // retry when the native lib explicitly reports an error.
+                val migrationSucceeded = if (result.startsWith("Migrated hostname for")) {
+                    true
+                } else {
+                    val errorMsg = try {
+                        JSONObject(result).optString("error", null)
+                    } catch (e: JSONException) {
+                        result.ifEmpty { "empty response" }
+                    }
+                    Log.w(TAG, "Hostname migration failed ($errorMsg); will retry on next start")
                     false
                 }
                 if (migrationSucceeded) {
                     prefs.setHostnameMigrated()
-                } else {
-                    Log.w(TAG, "Hostname migration reported failure; will retry on next start")
                 }
             }
         }

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -72,7 +72,7 @@ class BackgroundService : Service() {
                     true
                 } else {
                     val errorMsg = try {
-                        JSONObject(result).optString("error", null)
+                        JSONObject(result).optString("error", result)
                     } catch (e: JSONException) {
                         result.ifEmpty { "empty response" }
                     }


### PR DESCRIPTION
## Summary

Fixes a correctness bug where `setHostnameMigrated()` was never called, causing hostname migration to run on every app start indefinitely.

## Root Cause

The native `migrateHostname()` JNI function returns:
- **Success**: plain-text `"Migrated hostname for N bucket(s)"` (NOT JSON)
- **Error**: JSON `{"error": "message"}`

`BackgroundService` was trying to parse the success response as JSON with a `"success"` boolean key that never exists. This always threw a `JSONException`, set `migrationSucceeded = false`, and skipped `setHostnameMigrated()` — so migration would re-run on every subsequent app start.

On fresh install this produced two spurious logcat warnings even though migration succeeded normally with 0 buckets:
```
I BackgroundService: Hostname migration result: Migrated hostname for 0 bucket(s)
W BackgroundService: Migration result was not valid JSON; will retry on next start
W BackgroundService: Hostname migration reported failure; will retry on next start
```

## Fix

Check for the known plain-text success prefix first. Only attempt JSON parsing for the error case, extracting the `"error"` field for a single informative warning.

## Test plan

- [ ] Fresh install (no prior data): migration runs, `setHostnameMigrated()` is called, no spurious warnings, migration does not re-run on next start
- [ ] Install with existing `unknown`/`Unknown` hostname buckets: migration renames them, `setHostnameMigrated()` called, migration does not re-run
- [ ] Server not ready on first start (error path): single `W Hostname migration failed (...)` warning, migration retries on next start

Fixes #171