### PR TITLE
fix(ci): validate all jniLibs ABIs and exclude armeabi-v7a from debug builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,37 +83,7 @@ jobs:
 
     - name: Check that jniLibs present and valid ELF
       run: |
-        python3 - <<'EOF'
-        import os, struct, sys
-        abis = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
-        ok = True
-        for abi in abis:
-            path = f'mobile/src/main/jniLibs/{abi}/libaw_server.so'
-            if not os.path.exists(path):
-                print(f'MISSING  {path}', file=sys.stderr)
-                ok = False
-                continue
-            fsize = os.path.getsize(path)
-            with open(path, 'rb') as f:
-                header = f.read(64)
-            if header[:4] != b'\x7fELF':
-                print(f'NOT_ELF  {path}', file=sys.stderr)
-                ok = False
-                continue
-            e_class = header[4]  # 1=32-bit, 2=64-bit
-            if e_class == 1:
-                e_shoff = struct.unpack('<I', header[32:36])[0]
-            else:
-                e_shoff = struct.unpack('<Q', header[40:48])[0]
-            if e_shoff != 0 and e_shoff >= fsize:
-                print(f'CORRUPT  {path}: section header past EOF '
-                      f'(e_shoff=0x{e_shoff:x}, size={fsize})', file=sys.stderr)
-                ok = False
-                continue
-            print(f'OK       {abi}/libaw_server.so  ({fsize:,} bytes)')
-        if not ok:
-            sys.exit(1)
-        EOF
+        python3 scripts/check-jnilibs.py
 
     - name: Upload jniLibs artifact
       uses: actions/upload-artifact@v4
@@ -235,9 +205,9 @@ jobs:
         key: ${{ env.cache-name }}-release-${{ env.RELEASE }}-ndk-${{ env.NDK_VERSION }}-${{ hashFiles('.git/modules/aw-server-rust/HEAD') }}
         fail-on-cache-miss: false
 
-    - name: Check that jniLibs present
+    - name: Check that jniLibs present and valid ELF
       run: |
-        test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
+        python3 scripts/check-jnilibs.py
 
     - name: Verify versionName matches tag
       if: startsWith(github.ref, 'refs/tags/v')  # only on runs triggered from tag
@@ -319,9 +289,9 @@ jobs:
         name: jniLibs
         path: mobile/src/main/jniLibs/
 
-    - name: Check that jniLibs present
+    - name: Check that jniLibs present and valid ELF
       run: |
-        test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
+        python3 scripts/check-jnilibs.py
 
     # Test
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,39 @@ jobs:
       run: |
         make aw-server-rust
 
-    - name: Check that jniLibs present
+    - name: Check that jniLibs present and valid ELF
       run: |
-        test -e mobile/src/main/jniLibs/x86_64/libaw_server.so
+        python3 - <<'EOF'
+        import os, struct, sys
+        abis = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+        ok = True
+        for abi in abis:
+            path = f'mobile/src/main/jniLibs/{abi}/libaw_server.so'
+            if not os.path.exists(path):
+                print(f'MISSING  {path}', file=sys.stderr)
+                ok = False
+                continue
+            fsize = os.path.getsize(path)
+            with open(path, 'rb') as f:
+                header = f.read(64)
+            if header[:4] != b'\x7fELF':
+                print(f'NOT_ELF  {path}', file=sys.stderr)
+                ok = False
+                continue
+            e_class = header[4]  # 1=32-bit, 2=64-bit
+            if e_class == 1:
+                e_shoff = struct.unpack('<I', header[32:36])[0]
+            else:
+                e_shoff = struct.unpack('<Q', header[40:48])[0]
+            if e_shoff != 0 and e_shoff >= fsize:
+                print(f'CORRUPT  {path}: section header past EOF '
+                      f'(e_shoff=0x{e_shoff:x}, size={fsize})', file=sys.stderr)
+                ok = False
+                continue
+            print(f'OK       {abi}/libaw_server.so  ({fsize:,} bytes)')
+        if not ok:
+            sys.exit(1)
+        EOF
 
     - name: Upload jniLibs artifact
       uses: actions/upload-artifact@v4

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -38,6 +38,13 @@ android {
             applicationIdSuffix ".debug"
             jniDebuggable true
             renderscriptDebuggable true
+            // Limit debug APK to modern ABIs used by CI emulators and physical devices.
+            // armeabi-v7a debug Rust binaries are very large and can corrupt the CI
+            // artifact when disk space is tight; they aren't needed for x86_64 emulator
+            // runs or any arm64-v8a device released since ~2014.
+            ndk {
+                abiFilters 'arm64-v8a', 'x86_64'
+            }
         }
     }
     compileOptions {

--- a/scripts/check-jnilibs.py
+++ b/scripts/check-jnilibs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import struct
+import sys
+
+
+ABIS = ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
+LIB_NAME = "libaw_server.so"
+
+
+def check_lib(abi):
+    path = os.path.join("mobile", "src", "main", "jniLibs", abi, LIB_NAME)
+    if not os.path.exists(path):
+        print(f"MISSING  {path}", file=sys.stderr)
+        return False
+
+    fsize = os.path.getsize(path)
+    with open(path, "rb") as f:
+        header = f.read(64)
+
+    if header[:4] != b"\x7fELF":
+        print(f"NOT_ELF  {path}", file=sys.stderr)
+        return False
+
+    if len(header) < 64:
+        print(
+            f"CORRUPT  {path}: file too small for ELF header "
+            f"({len(header)} bytes)",
+            file=sys.stderr,
+        )
+        return False
+
+    e_class = header[4]  # 1=32-bit, 2=64-bit
+    if e_class == 1:
+        e_shoff = struct.unpack("<I", header[32:36])[0]
+    elif e_class == 2:
+        e_shoff = struct.unpack("<Q", header[40:48])[0]
+    else:
+        print(f"CORRUPT  {path}: unknown ELF class {e_class}", file=sys.stderr)
+        return False
+
+    if e_shoff != 0 and e_shoff >= fsize:
+        print(
+            f"CORRUPT  {path}: section header past EOF "
+            f"(e_shoff=0x{e_shoff:x}, size={fsize})",
+            file=sys.stderr,
+        )
+        return False
+
+    print(f"OK       {abi}/{LIB_NAME}  ({fsize:,} bytes)")
+    return True
+
+
+def main():
+    ok = True
+    for abi in ABIS:
+        ok = check_lib(abi) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Master CI has been failing since 2026-07-02 with two distinct issues:

### 1. `INSTALL_FAILED_NO_MATCHING_ABIS` in E2E tests

Root cause chain:
1. PR #160 upgraded `actions/cache v3→v4`. GitHub Actions cache v4 uses a different backend, so all old v3 caches were invalidated.
2. Cache miss triggered a fresh Rust debug build for **all 4 ABIs** (arm7, arm8, x86, x86_64).
3. Debug Rust binaries are very large (~160MB+ for armeabi-v7a). Building all 4 in debug mode appears to exhaust runner disk space, truncating `armeabi-v7a/libaw_server.so` mid-write (corrupt ELF: `e_shoff=0x9d93a8c` past EOF).
4. The old jniLibs check only verified `x86_64/libaw_server.so` exists — so the corrupt arm7 file passed silently and was uploaded as the artifact.
5. The E2E test job downloads the jniLibs, Gradle's `mergeDebugNativeLibs` tries to `llvm-strip` the corrupt arm7 `.so`, and fails with:
   ```
   section header table goes past the end of the file: e_shoff = 0x9d93a8c
   INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries, res=-113
   ```

### 2. `age: no identity matched any of the recipients` (not addressed here)

The `KEY_FASTLANE_API` signing secret no longer matches the encrypted `.age` file. This is a separate signing-infrastructure issue requiring secret rotation — not addressed in this PR.

## Fixes

### `build.yml` — Comprehensive jniLibs validity check

Replaces the x86_64-existence-only check with a Python script that validates **all 4 ABIs** for:
- File presence
- Valid ELF magic (`\x7fELF`)  
- Section header table offset within file bounds

This catches corruption **at build-rust time** with a clear diagnostic instead of a cryptic `INSTALL_FAILED_NO_MATCHING_ABIS` deep in the E2E logs.

### `mobile/build.gradle` — Exclude legacy ABIs from debug builds

Adds `abiFilters 'arm64-v8a', 'x86_64'` to the `debug` build type.

- The CI E2E emulator is `x86_64`. It never needs armeabi-v7a or x86 libs.
- Physical devices since ~2014 use arm64-v8a; armeabi-v7a support is legacy.
- This prevents a corrupt arm7 `.so` from ever blocking the E2E install, even if the CI check is bypassed in future.
- Release builds are unaffected (no `abiFilters` on release).

## Testing

The ELF validity check is straightforward Python using only stdlib (`os`, `struct`). The abiFilters change follows the standard Android Gradle Plugin pattern for per-variant ABI filtering.

The `age` signing failure means the full `build-aab` / `build-apk` jobs will still fail until the signing secret is rotated, but the `test-e2e` job should pass once the jniLibs cache is populated for the v4 backend (or after one successful fresh build where arm7 isn't corrupted).