### PR TITLE
ci: add workflow_dispatch to Build + warn when RELEASE_PAT is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
       - v*
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    # Allows manually triggering a build on any branch or tag.
+    # Useful when RELEASE_PAT is missing and a tag push didn't auto-trigger this workflow.
+    # Usage: gh workflow run build.yml --repo ActivityWatch/aw-android --ref refs/tags/v<version>
 
 env:
   NDK_VERSION: '25.2.9519653'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ jobs:
       contents: write
 
     steps:
+      - name: Check for RELEASE_PAT
+        run: |
+          if [ -z "${{ secrets.RELEASE_PAT }}" ]; then
+            echo "::warning::RELEASE_PAT secret is not set. Falling back to GITHUB_TOKEN."
+            echo "::warning::GitHub prevents GITHUB_TOKEN pushes from triggering other workflows."
+            echo "::warning::After this run, manually trigger the Build workflow:"
+            echo "::warning::  gh workflow run build.yml --repo ActivityWatch/aw-android --ref refs/tags/v${{ inputs.version }}"
+            echo "::warning::Or add RELEASE_PAT (Settings → Secrets → Actions) to fix this permanently."
+          fi
+
       - uses: actions/checkout@v4
         with:
           # RELEASE_PAT is a repo-scoped PAT; its pushes trigger the Build workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,14 @@ jobs:
 
     steps:
       - name: Check for RELEASE_PAT
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           if [ -z "${{ secrets.RELEASE_PAT }}" ]; then
             echo "::warning::RELEASE_PAT secret is not set. Falling back to GITHUB_TOKEN."
             echo "::warning::GitHub prevents GITHUB_TOKEN pushes from triggering other workflows."
             echo "::warning::After this run, manually trigger the Build workflow:"
-            echo "::warning::  gh workflow run build.yml --repo ActivityWatch/aw-android --ref refs/tags/v${{ inputs.version }}"
+            echo "::warning::  gh workflow run build.yml --repo ActivityWatch/aw-android --ref refs/tags/v${VERSION}"
             echo "::warning::Or add RELEASE_PAT (Settings → Secrets → Actions) to fix this permanently."
           fi
 


### PR DESCRIPTION
## Problem

When `RELEASE_PAT` is not set (or expired), the Release workflow falls back to `GITHUB_TOKEN` for its tag push. GitHub's security model prevents `GITHUB_TOKEN`-authored pushes from triggering other workflow runs — so the tag is created correctly but the Build workflow never fires.

This happened with the v0.14.0 release: the tag exists at the right commit, but no build was triggered.

## Changes

### `build.yml` — add `workflow_dispatch` trigger

Allows manually launching a build on any branch or tag:

```bash
# After a failed Release run (RELEASE_PAT missing), manually trigger the build:
gh workflow run build.yml --repo ActivityWatch/aw-android --ref refs/tags/v0.14.0
```

All existing checks (`startsWith(github.ref_name, 'v')` for RELEASE mode, `release-fastlane`, `release-gh` conditionals) work correctly when dispatched on a tag ref.

> **Note**: For the current `v0.14.0` tag, this workflow file isn't at that tag yet. Erik still needs to manually re-push the tag with a personal token (see issue #176). This fix helps future releases.

### `release.yml` — add RELEASE_PAT warning step

Detects when the secret is absent and emits a `::warning::` annotation with the exact command to manually trigger the build, so operators immediately know what to do next.

## Testing

The `workflow_dispatch` trigger is structurally minimal — no inputs, just the trigger. CI on this PR itself will validate the workflow file is syntactically valid.

Closes #177 (if such an issue is created for the workflow improvement).

Related: ActivityWatch/aw-android#176