### PR TITLE
build: bump targetSdkVersion/compileSdk to 35 (Android 15)

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,0 +1,4 @@
+v0.14.0
+
+- Updated to target Android 15 (API 35)
+- Bug fixes and stability improvements

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 35
     ndkVersion "25.2.9519653"
 
     defaultConfig {
         applicationId "net.activitywatch.android"
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         // Keep versionName committed in source so tagged builds and F-Droid agree.
         // Tag workflows verify it matches refs/tags/v* instead of rewriting the checkout.

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     val version: String
         get() {
-            return packageManager.getPackageInfo(packageName, 0).versionName
+            return packageManager.getPackageInfo(packageName, 0).versionName ?: "unknown"
         }
 
     override fun onFragmentInteraction(item: Uri) {

--- a/mobile/src/main/res/values-v35/styles.xml
+++ b/mobile/src/main/res/values-v35/styles.xml
@@ -11,4 +11,10 @@
         <item name="android:textColor">@color/default_text_color</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 </resources>

--- a/mobile/src/main/res/values-v35/styles.xml
+++ b/mobile/src/main/res/values-v35/styles.xml
@@ -1,0 +1,14 @@
+<resources>
+    <!--
+        Android 15 (API 35) enforces edge-to-edge display for all apps targeting SDK 35.
+        Opt out here until the app's WebView-based UI is updated to handle insets.
+        See https://developer.android.com/develop/ui/views/layout/edge-to-edge
+    -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:textColor">@color/default_text_color</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Problem

The v0.14.0 release CI failed at the Play Store upload step with:

```
Google Api Error: Invalid request - Target SDK of artifact is too low: 35.
```

Google Play now requires `targetSdkVersion >= 35` for new/updated app submissions (enforced as of August 2025).

## Changes

- **compileSdk 34 → 35** and **targetSdkVersion 34 → 35**
- **`values-v35/styles.xml`**: Add `android:windowOptOutEdgeToEdgeEnforcement=true` to opt out of Android 15's mandatory edge-to-edge display enforcement until the WebView-based UI is updated to properly handle window insets
- **`fastlane/metadata/android/en-US/changelogs/35.txt`**: Adds v0.14.0 release notes for versionCode 35 (fixes the non-fatal CI warning "Could not find changelog for '35'")

## Why the edge-to-edge opt-out?

Android 15 (API 35) mandates edge-to-edge display for all apps targeting SDK 35. Since aw-android uses a WebView for the main UI, the layout would likely break (status/navigation bars overlapping content) without either implementing proper insets handling or opting out. The opt-out is placed in `values-v35/styles.xml` so it only applies on Android 15+ devices.

Once the UI is updated to handle insets, `android:windowOptOutEdgeToEdgeEnforcement` can be removed.

## Next steps (follow-up, not in this PR)

- Implement proper edge-to-edge insets handling in the WebView activity
- Add automatic changelog generation to the release workflow (so each release doesn't need a manually-written `changelogs/<versionCode>.txt`)