### PR TITLE
fix(ci): add rubygems.org source before fastlane release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,6 +456,9 @@ jobs:
 
     - name: Release with fastlane
       run: |
+        # Newer fastlane versions fail hard if rubygems.org isn't in the system gem sources list.
+        # This is idempotent (exits 0 if already present).
+        gem sources --add https://rubygems.org
         # bundle exec fastlane supply run --apk dist/*.apk
         bundle exec fastlane supply run --aab dist/*.aab
 


### PR DESCRIPTION
## Problem

The `release-fastlane` job fails in the \"Release with fastlane\" step with:

```
[31mRubyGems is not listed as your Gem source[0m
[31mYou can run \`gem sources\` to see all your sources[0m
[36m\$ gem sources --add https://rubygems.org[0m
Process completed with exit code 1.
```

This was observed in the v0.14.0 release run (https://github.com/ActivityWatch/aw-android/actions/runs/29175779069).

**Root cause**: Newer fastlane versions (2.236+) added a hard check that exits with code 1 if `https://rubygems.org` is not in the system gem sources list. The `Gemfile.lock` pins fastlane at 2.216.0 which didn't have this check, but the bundler cache can drift to a newer version between long gaps between releases (last release was Oct 2023).

The `release-gh` job succeeded (GitHub release created), but the Play Store upload via fastlane did not complete.

## Fix

Add `gem sources --add https://rubygems.org` before the fastlane command. This is idempotent — exits 0 if already present.

## Test plan

- [ ] Trigger a release workflow and verify `release-fastlane` job reaches the Play Store upload step
- [ ] Alternatively, re-run the failed job from the v0.14.0 build run