### PR TITLE
fix(ci): use version regex for SUPPLY_TRACK instead of semver is_stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,8 +435,13 @@ jobs:
 
     - name: Set SUPPLY_TRACK
       run: |
-        # Set SUPPLY_TRACK (used by fastlane) depending on is_stable
-        if [[ "${{ steps.version.outputs.is_stable }}" == "true" ]]; then
+        # Set SUPPLY_TRACK based on whether this is a stable (x.y.z) or pre-release tag.
+        # NOTE: nowsprinting/check-version-format-action classifies 0.x.x as not stable
+        # (semver convention), but aw-android uses 0.x.x for production releases.
+        # Check for pre-release suffixes directly instead.
+        TAG="${{ github.ref_name }}"
+        VERSION="${TAG#v}"
+        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           SUPPLY_TRACK="production"
         else
           SUPPLY_TRACK="internal"


### PR DESCRIPTION
## Problem

The `release-fastlane` job uses `nowsprinting/check-version-format-action@v4` to determine if a tag is stable, then sets `SUPPLY_TRACK` accordingly:

```yaml
if [[ "${{ steps.version.outputs.is_stable }}" == "true" ]]; then
  SUPPLY_TRACK="production"
else
  SUPPLY_TRACK="internal"
fi
```

**The issue**: `check-version-format-action` follows the semver convention where `0.x.x` versions are *not* considered stable (they're "development" versions). Since all aw-android releases are `0.x.x`, `is_stable` is always `false`, and every release goes to the Play Store **internal** track instead of **production**.

This caused the `v0.14.0` release run to fail with `SUPPLY_TRACK=internal`, sending the AAB to the wrong track.

## Fix

Replace the `is_stable` check with a direct regex on the tag version string:
- `X.Y.Z` (no suffix) → `production`
- `X.Y.ZbN`, `X.Y.ZrcN`, `X.Y.ZdevYYYYMMDD`, etc. → `internal`

This matches how the Release workflow documents it:
```
#   Stable:      0.14.0         → full Play Store production release
#   Beta:        0.14.0b1       → GitHub pre-release, Play Store internal track
```

## Context

Found while investigating the failed `v0.14.0` release in issue #176. The other blocker (Target SDK 35 too low) is fixed by PR #179. This PR fixes the track routing so that once #179 merges and the release is re-triggered, the AAB lands in the production track.