### PR TITLE
fix: use Build.DEVICE instead of Build.MODEL for hostname fallback

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -172,8 +172,10 @@ class RustInterface(context: Context? = null) {
     }
 
     fun getDeviceName(context: Context): String {
-        return Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
-            ?: android.os.Build.DEVICE ?: "Unknown"
+        val raw = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+            ?: android.os.Build.DEVICE
+            ?: "unknown"
+        return raw.trim().replace(' ', '_').lowercase()
     }
 
 }

--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -173,7 +173,7 @@ class RustInterface(context: Context? = null) {
 
     fun getDeviceName(context: Context): String {
         return Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
-            ?: android.os.Build.MODEL ?: "Unknown"
+            ?: android.os.Build.DEVICE ?: "Unknown"
     }
 
 }

--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -175,7 +175,11 @@ class RustInterface(context: Context? = null) {
         val raw = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
             ?: android.os.Build.DEVICE
             ?: "unknown"
-        return raw.trim().replace(' ', '_').lowercase()
+        return raw.trim()
+            .lowercase(java.util.Locale.ROOT)
+            .replace(Regex("[^a-z0-9_-]+"), "_")
+            .trim('_')
+            .ifEmpty { "unknown" }
     }
 
 }

--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -173,6 +173,8 @@ class RustInterface(context: Context? = null) {
 
     fun getDeviceName(context: Context): String {
         val raw = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
             ?: android.os.Build.DEVICE
             ?: "unknown"
         return raw.trim()

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -63,8 +63,13 @@ class SyncInterface(context: Context) {
         val raw = android.provider.Settings.Global.getString(
             appContext.contentResolver,
             android.provider.Settings.Global.DEVICE_NAME
-        ) ?: android.os.Build.DEVICE ?: "unknown"
-        return raw.trim().replace(' ', '_').lowercase()
+        )?.trim()?.takeIf { it.isNotEmpty() }
+            ?: android.os.Build.DEVICE ?: "unknown"
+        return raw.trim()
+            .lowercase(java.util.Locale.ROOT)
+            .replace(Regex("[^a-z0-9_-]+"), "_")
+            .trim('_')
+            .ifEmpty { "unknown" }
     }
     
     // Async wrapper for syncPullAll

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -60,10 +60,11 @@ class SyncInterface(context: Context) {
     external fun getSyncDir(): String
     
     private fun getDeviceName(): String {
-        return android.provider.Settings.Global.getString(
-            appContext.contentResolver, 
+        val raw = android.provider.Settings.Global.getString(
+            appContext.contentResolver,
             android.provider.Settings.Global.DEVICE_NAME
-        ) ?: android.os.Build.DEVICE ?: "Unknown"
+        ) ?: android.os.Build.DEVICE ?: "unknown"
+        return raw.trim().replace(' ', '_').lowercase()
     }
     
     // Async wrapper for syncPullAll

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -63,7 +63,7 @@ class SyncInterface(context: Context) {
         return android.provider.Settings.Global.getString(
             appContext.contentResolver, 
             android.provider.Settings.Global.DEVICE_NAME
-        ) ?: android.os.Build.MODEL ?: "Unknown"
+        ) ?: android.os.Build.DEVICE ?: "Unknown"
     }
     
     // Async wrapper for syncPullAll


### PR DESCRIPTION
## Problem

`getDeviceName()` in `RustInterface.kt` and `SyncInterface.kt` falls back to `android.os.Build.MODEL` when `Settings.Global.DEVICE_NAME` is null. `Build.MODEL` returns the OEM marketing name (e.g. `"Poco F8 Ultra"`) which contains spaces — that breaks hostname-based bucket matching in aw-webui and aw-server.

Reported in #176: a Xiaomi Poco F8 Ultra produced `"Poco F8 Ultra"` as its hostname. The webui then fails to associate it with the Android bucket view because the hostname contains spaces.

## Fix

Replace the `Build.MODEL` fallback with `Build.DEVICE`, which returns the device codename (`poco_f8_ultra` — lowercase, underscore-delimited, no spaces). This is the correct format for a network hostname.

| Property | Example value | Hostname-safe? |
|---|---|---|
| `Settings.Global.DEVICE_NAME` | `"Poco F8 Ultra"` | ❌ (spaces) |
| `Build.MODEL` | `"Poco F8 Ultra"` | ❌ (spaces) |
| `Build.DEVICE` | `"poco_f8_ultra"` | ✅ |

## Changes

- `RustInterface.kt`: `Build.MODEL` → `Build.DEVICE`
- `SyncInterface.kt`: `Build.MODEL` → `Build.DEVICE`

Closes #176 (contributes — the hostname fix is one part of the broader stability tracker).