### PR TITLE
feat(sync): disable automatic sync by default

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -36,4 +36,14 @@ class AWPreferences(context: Context) {
     fun setHostnameMigrated() {
         sharedPreferences.edit().putBoolean("hasMigratedHostname", true).apply()
     }
+
+    // Sync is off by default; user must explicitly enable it once a sync directory
+    // is configured (e.g. via Storage Access Framework).
+    fun isSyncEnabled(): Boolean {
+        return sharedPreferences.getBoolean("syncEnabled", false)
+    }
+
+    fun setSyncEnabled(enabled: Boolean) {
+        sharedPreferences.edit().putBoolean("syncEnabled", enabled).apply()
+    }
 }

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -85,8 +85,14 @@ class BackgroundService : Service() {
             }
         }
 
-        // Start the sync scheduler
-        syncScheduler.start()
+        // Start the sync scheduler only when the user has enabled sync.
+        // Default is off — the sync directory is not accessible to other apps
+        // (Android scoped storage), so auto-sync would silently no-op for most users.
+        if (prefs.isSyncEnabled()) {
+            syncScheduler.start()
+        } else {
+            Log.i(TAG, "Sync is disabled (default). Enable it in settings to start syncing.")
+        }
 
         // Schedule event parsing
         scheduleEventParsing()

--- a/mobile/src/main/java/net/activitywatch/android/SyncAlarmReceiver.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncAlarmReceiver.kt
@@ -16,6 +16,10 @@ class SyncAlarmReceiver : BroadcastReceiver() {
 
         when (intent.action) {
             "net.activitywatch.android.SYNC_ALARM" -> {
+                if (!AWPreferences(context).isSyncEnabled()) {
+                    Log.i(TAG, "Sync is disabled; skipping alarm-triggered sync")
+                    return
+                }
                 Log.i(TAG, "Performing scheduled sync...")
                 val pendingResult = goAsync()
                 // Create SyncInterface and perform sync on IO dispatcher to avoid

--- a/mobile/src/main/java/net/activitywatch/android/SyncAlarmReceiver.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncAlarmReceiver.kt
@@ -17,7 +17,8 @@ class SyncAlarmReceiver : BroadcastReceiver() {
         when (intent.action) {
             "net.activitywatch.android.SYNC_ALARM" -> {
                 if (!AWPreferences(context).isSyncEnabled()) {
-                    Log.i(TAG, "Sync is disabled; skipping alarm-triggered sync")
+                    Log.i(TAG, "Sync is disabled; cancelling stale alarm")
+                    SyncScheduler.cancelAlarm(context)
                     return
                 }
                 Log.i(TAG, "Performing scheduled sync...")

--- a/mobile/src/main/java/net/activitywatch/android/SyncScheduler.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncScheduler.kt
@@ -105,4 +105,24 @@ class SyncScheduler(private val context: Context) {
             }
         }
     }
+
+    companion object {
+        // Called by SyncAlarmReceiver when sync is disabled, to cancel a stale alarm left
+        // from a previous enable session or an older build that registered it before the pref existed.
+        fun cancelAlarm(context: Context) {
+            val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(ACTION_SYNC_ALARM).setPackage(context.packageName)
+            val pi = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+            )
+            if (pi != null) {
+                am.cancel(pi)
+                pi.cancel()
+                Log.i(TAG, "Cancelled stale AlarmManager sync alarm (sync disabled)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Background

Closes ActivityWatch/activitywatch#1357 (partial — addresses the default-off requirement; Storage Access Framework setup flow is a follow-up).

## Problem

`SyncScheduler` fires every 15 minutes unconditionally, but Android sync is effectively broken for most users:

- The sync directory (`Android/data/net.activitywatch.android/files/sync/`) is app-scoped storage, inaccessible to Syncthing and other sync clients since Android 11 scoped storage restrictions.
- `pull_all()` silently no-ops (no remote db files found).
- `push` works, but data stays trapped on the phone.
- Running the scheduler in this state wastes battery/I-O and risks the OOM crash described in ActivityWatch/aw-server-rust#630.

## Changes

**`AWPreferences.kt`** — adds `isSyncEnabled()` (default: `false`) and `setSyncEnabled(Boolean)`. The `false` default means new installs won't start the scheduler automatically. `setSyncEnabled(true)` is the hook for a future settings toggle or Storage Access Framework setup flow.

**`BackgroundService.kt`** — gates `syncScheduler.start()` on `prefs.isSyncEnabled()`. If disabled, logs a message instead of starting the 15-minute chain.

**`SyncAlarmReceiver.kt`** — gates the AlarmManager fallback path on the same preference. Without this, an alarm registered before a downgrade/reinstall could still fire sync even with the new default.

## What's not in this PR

- Settings UI toggle (follow-up — needs a settings screen)
- Storage Access Framework directory picker (follow-up — larger change)
- Docs update at docs.activitywatch.net/en/latest/syncing.html (follow-up in main repo)

## Testing

- Fresh install: `AWPreferences.isSyncEnabled()` returns `false` → scheduler never starts.
- Existing install: preference key `syncEnabled` is absent in SharedPreferences → same `false` default applies.
- `setSyncEnabled(true)` → scheduler starts on next `BackgroundService.onStartCommand()`.