### PR TITLE
fix: CSV/JSON export via WebAppInterface + FileProvider (fixes #104)

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -113,5 +113,15 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/category_time_widget_info" />
         </receiver>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
+++ b/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.net.Uri
 import android.os.Bundle
+import android.webkit.JavascriptInterface
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -18,6 +20,7 @@ import android.webkit.URLUtil
 import android.webkit.WebResourceRequest
 import android.webkit.WebViewClient
 import net.activitywatch.android.R
+import java.io.File
 import java.lang.Thread.sleep
 import java.net.URI
 
@@ -117,6 +120,7 @@ class WebUIFragment : Fragment() {
 
         myWebView.settings.javaScriptEnabled = true
         myWebView.settings.domStorageEnabled = true
+        myWebView.addJavascriptInterface(WebAppInterface(requireContext()), "Android")
         arguments?.let {
             it.getString(ARG_URL)?.let { it1 -> myWebView.loadUrl(it1) }
         }
@@ -163,5 +167,32 @@ class WebUIFragment : Fragment() {
                     putString(ARG_URL, url)
                 }
             }
+    }
+}
+
+class WebAppInterface(private val mContext: Context) {
+    @JavascriptInterface
+    fun downloadCSV(csv: String, filename: String) {
+        downloadFile(csv, filename, "text/csv")
+    }
+
+    @JavascriptInterface
+    fun downloadJSON(json: String, filename: String) {
+        downloadFile(json, filename, "application/json")
+    }
+
+    private fun downloadFile(content: String, filename: String, mimetype: String) {
+        val file = File(mContext.getExternalFilesDir(null), filename)
+        file.writeText(content)
+        // FileProvider required on API 24+: Uri.fromFile() throws FileUriExposedException
+        val uri = FileProvider.getUriForFile(
+            mContext,
+            "${mContext.packageName}.provider",
+            file
+        )
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.setDataAndType(uri, mimetype)
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NO_HISTORY)
+        mContext.startActivity(intent)
     }
 }

--- a/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
+++ b/mobile/src/main/java/net/activitywatch/android/fragments/WebUIFragment.kt
@@ -1,6 +1,7 @@
 package net.activitywatch.android.fragments
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
@@ -182,8 +183,19 @@ class WebAppInterface(private val mContext: Context) {
     }
 
     private fun downloadFile(content: String, filename: String, mimetype: String) {
-        val file = File(mContext.getExternalFilesDir(null), filename)
-        file.writeText(content)
+        // Strip path components from the JS-supplied name to prevent export-root escape
+        val safeName = File(filename).name.takeIf { it.isNotEmpty() } ?: "export"
+        val externalDir = mContext.getExternalFilesDir(null) ?: run {
+            Log.e(TAG, "External files directory unavailable")
+            return
+        }
+        val file = File(externalDir, safeName)
+        try {
+            file.writeText(content)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write export file: ${e.message}")
+            return
+        }
         // FileProvider required on API 24+: Uri.fromFile() throws FileUriExposedException
         val uri = FileProvider.getUriForFile(
             mContext,
@@ -193,6 +205,10 @@ class WebAppInterface(private val mContext: Context) {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.setDataAndType(uri, mimetype)
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NO_HISTORY)
-        mContext.startActivity(intent)
+        try {
+            mContext.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(TAG, "No viewer app found for $mimetype", e)
+        }
     }
 }

--- a/mobile/src/main/res/xml/file_paths.xml
+++ b/mobile/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-files-path name="external_files" path="." />
+</paths>


### PR DESCRIPTION
Takes over from ActivityWatch/aw-android#109 (Erik asked @TimeToBuildBob to take over).

## Problem

The original crash (#104) happens because the Android WebView can't trigger system downloads the way a desktop browser does. PR #109 addressed this with a `JavascriptInterface` bridge — the right approach — but used `Uri.fromFile()` which throws `FileUriExposedException` on Android 7.0+ (API 24+), causing a new crash.

## Fix

- **`WebUIFragment.kt`**: Adds `WebAppInterface` exposing `downloadCSV()` / `downloadJSON()` to `window.Android`, wired into the WebView via `addJavascriptInterface`. Uses `FileProvider.getUriForFile()` instead of `Uri.fromFile()` with `FLAG_GRANT_READ_URI_PERMISSION` so the viewer app can read the file.
- **`AndroidManifest.xml`**: Declares the `FileProvider` with `${applicationId}.provider` authority.
- **`res/xml/file_paths.xml`**: Provider path config scoped to `getExternalFilesDir(null)`.

## Dependencies

Depends on ActivityWatch/aw-webui#532 (adds the `window.Android.downloadCSV()` call on the webui side).

## Testing

Could not run the Android emulator in this environment. The pattern (FileProvider + `@JavascriptInterface`) is the standard Android approach for WebView→native file sharing since API 24.