### PR TITLE
fix(hostname): use Build.DEVICE instead of Settings.Global.DEVICE_NAME

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -3,7 +3,6 @@ package net.activitywatch.android
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.provider.Settings
 import android.system.Os
 import android.util.Log
 import java.util.concurrent.Executors
@@ -172,11 +171,11 @@ class RustInterface(context: Context? = null) {
     }
 
     fun getDeviceName(context: Context): String {
-        val raw = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?: android.os.Build.DEVICE
-            ?: "unknown"
+        // Use Build.DEVICE (hardware codename, e.g. "poco_f8_ultra") rather than
+        // Settings.Global.DEVICE_NAME (OEM marketing name, e.g. "Poco F8 Ultra").
+        // Marketing names contain spaces and vary by locale, breaking hostname-based
+        // bucket lookup in aw-webui. Build.DEVICE is stable and already underscore-delimited.
+        val raw = android.os.Build.DEVICE?.takeIf { it.isNotEmpty() } ?: "unknown"
         return raw.trim()
             .lowercase(java.util.Locale.ROOT)
             .replace(Regex("[^a-z0-9_-]+"), "_")


### PR DESCRIPTION
## Problem

`getDeviceName()` was using `Settings.Global.DEVICE_NAME` as the primary hostname source. On many Android devices (particularly Xiaomi/POCO), this returns the OEM marketing name — e.g. `"Poco F8 Ultra"` with spaces and mixed case. While the existing normalization step converts this to `"poco_f8_ultra"`, relying on `DEVICE_NAME` introduces OEM-specific and locale-specific variation.

The symptom: aw-webui's Raw Data (Buckets) view shows `"Poco F8 Ultra"` as the device hostname instead of a clean machine-readable identifier.

## Fix

Use `Build.DEVICE` (the hardware codename, e.g. `"poco_f8_ultra"`) as the primary source. It is:
- Stable across reboots and locale changes
- Already lowercase and underscore-delimited on most devices
- Not subject to OEM customization of display names

The normalization step (lowercase + replace non-alphanumeric with `_`) is kept for any edge cases where `Build.DEVICE` might contain unusual characters.

## Migration

Existing buckets created with a `DEVICE_NAME`-derived hostname are migrated by the existing `migrateHostname()` call in `BackgroundService`. On most devices the computed hostname is identical either way (since `Build.DEVICE` is already normalized), so migration is a no-op for clean installs.

## Related

Discussed in ActivityWatch/aw-android#176.

cc @ErikBjare