### PR TITLE
fix: remove FOREGROUND_SERVICE_DATA_SYNC permission (unblocks v0.14.0 Play Store upload)

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -80,7 +80,11 @@
             android:name=".BackgroundService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="specialUse" />
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="ActivityWatch runs a local HTTP server on-device to store and serve app usage data. All data stays on-device. The foreground service keeps the server continuously available so the ActivityWatch web UI remains accessible to the user. No predefined foreground service type (camera, microphone, location, health, media, etc.) covers this use case." />
+        </service>
 
         <receiver
             android:name=".SyncAlarmReceiver"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <meta-data android:name="com.samsung.android.vr.application.mode" android:value="dual" />
 
@@ -79,8 +78,7 @@
         <service
             android:name=".BackgroundService"
             android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:exported="false" />
 
         <receiver
             android:name=".SyncAlarmReceiver"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <meta-data android:name="com.samsung.android.vr.application.mode" android:value="dual" />
 
@@ -78,7 +79,8 @@
         <service
             android:name=".BackgroundService"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="specialUse" />
 
         <receiver
             android:name=".SyncAlarmReceiver"

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -40,7 +41,10 @@ class BackgroundService : Service() {
             this,
             NOTIFICATION_ID,
             notification,
-            0
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            else
+                0
         )
         rustInterface = RustInterface(this)
         syncScheduler = SyncScheduler(this)

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -7,7 +7,6 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -41,10 +40,7 @@ class BackgroundService : Service() {
             this,
             NOTIFICATION_ID,
             notification,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            else
-                0
+            0
         )
         rustInterface = RustInterface(this)
         syncScheduler = SyncScheduler(this)


### PR DESCRIPTION
## Problem

The v0.14.0 fastlane Play Store upload fails with:
```
Google Api Error: Invalid request - You must let us know whether your app uses any Foreground Service permissions.
```

Google requires a policy declaration + demo video for `FOREGROUND_SERVICE_DATA_SYNC`. Since sync is disabled by default (#184) and not demonstrable yet, we can't satisfy the form requirement right now.

## Changes

- Remove `<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />` from `AndroidManifest.xml`
- Remove `android:foregroundServiceType="dataSync"` from `BackgroundService` declaration
- Change `startForeground()` call to use type `0` instead of `FOREGROUND_SERVICE_TYPE_DATA_SYNC`
- Remove now-unused `ServiceInfo` import

## Notes

The base `FOREGROUND_SERVICE` permission is retained — this covers the monitoring service. On Android 15 (targetSdk 35), using no foreground service type is the correct approach when none of the specific types apply.

Re-add `FOREGROUND_SERVICE_DATA_SYNC` and the `dataSync` service type when sync is functional and a demo video can be recorded.

Closes #189 (item 1)