### PR TITLE
fix(auth): call ensureDashboardApiKey on boot (BackgroundService)

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -53,6 +53,13 @@ class BackgroundService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(TAG, "BackgroundService started")
 
+        // Ensure the API key is written to config.toml before the server reads it.
+        // MainActivity does this when the user launches the app normally, but
+        // BackgroundService is also started on BOOT_COMPLETED (via SyncAlarmReceiver)
+        // without ever going through MainActivity, so we need to guarantee the key
+        // exists here as well.
+        ensureDashboardApiKey(this)
+
         // Start the server
         rustInterface.startServerTask()
 


### PR DESCRIPTION
## Problem

`BackgroundService.onStartCommand()` calls `rustInterface.startServerTask()` directly without first calling `ensureDashboardApiKey()`. This means that on a cold boot (`BOOT_COMPLETED` → `SyncAlarmReceiver` → `BackgroundService`), the server starts before `config.toml` has an `[auth]` section, leaving the dashboard unauthenticated until the user manually opens the app.

`MainActivity.onCreate()` calls `ensureDashboardApiKey()` before starting the service, so normal app launches were fine — only the boot path was affected.

## Fix

Call `ensureDashboardApiKey(this)` in `onStartCommand()` before `startServerTask()`. The call is idempotent (reads the existing key if one already exists) so it's safe to call here and in `MainActivity` — the config is written once and reused on subsequent calls.

## Related

Identified by Codex review of #157 (see comment from @ErikBjare on that PR).