### PR TITLE
fix(auth): persist auth-disabled setting across restarts

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -46,4 +46,16 @@ class AWPreferences(context: Context) {
     fun setSyncEnabled(enabled: Boolean) {
         sharedPreferences.edit().putBoolean("syncEnabled", enabled).apply()
     }
+
+    // Dashboard authentication. Defaults to true so first-run gets a key generated
+    // automatically. Set to false when the user explicitly disables auth in settings;
+    // ensureDashboardApiKey() checks this before generating a new key so that the
+    // "disabled" setting survives app restarts.
+    fun isDashboardAuthEnabled(): Boolean {
+        return sharedPreferences.getBoolean("dashboardAuthEnabled", true)
+    }
+
+    fun setDashboardAuthEnabled(enabled: Boolean) {
+        sharedPreferences.edit().putBoolean("dashboardAuthEnabled", enabled).apply()
+    }
 }

--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -56,6 +56,6 @@ class AWPreferences(context: Context) {
     }
 
     fun setDashboardAuthEnabled(enabled: Boolean) {
-        sharedPreferences.edit().putBoolean("dashboardAuthEnabled", enabled).apply()
+        sharedPreferences.edit().putBoolean("dashboardAuthEnabled", enabled).commit()
     }
 }

--- a/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -32,6 +33,9 @@ class AuthSettingsActivity : AppCompatActivity() {
 
     // Guards against the switch listener firing when we set isChecked programmatically
     private var isUpdatingSwitch = false
+
+    // Holds the active toggle coroutine so rapid flips cancel the previous one
+    private var toggleJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -88,7 +92,8 @@ class AuthSettingsActivity : AppCompatActivity() {
 
         switchAuthEnabled.setOnCheckedChangeListener { _: CompoundButton, isChecked: Boolean ->
             if (isUpdatingSwitch) return@setOnCheckedChangeListener
-            lifecycleScope.launch {
+            toggleJob?.cancel()
+            toggleJob = lifecycleScope.launch {
                 if (isChecked) {
                     val current = withContext(Dispatchers.IO) { configManager.readAuthConfig() }
                     if (!current.isEnabled) {
@@ -102,7 +107,7 @@ class AuthSettingsActivity : AppCompatActivity() {
                         // Only show the toast when a write actually happened
                         Toast.makeText(this@AuthSettingsActivity, "Setting saved. Restart app to apply.", Toast.LENGTH_SHORT).show()
                     }
-                    AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true)
+                    withContext(Dispatchers.IO) { AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true) }
                     btnCopy.visibility = View.VISIBLE
                     tvStatus.text = "Authentication enabled (restart app to apply)"
                 } else {
@@ -112,7 +117,7 @@ class AuthSettingsActivity : AppCompatActivity() {
                         Toast.makeText(this@AuthSettingsActivity, "Failed to save API key setting", Toast.LENGTH_LONG).show()
                         return@launch
                     }
-                    AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(false)
+                    withContext(Dispatchers.IO) { AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(false) }
                     tvApiKey.text = "(none)"
                     btnCopy.visibility = View.GONE
                     tvStatus.text = "Authentication disabled (restart app to apply)"

--- a/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
@@ -102,6 +102,7 @@ class AuthSettingsActivity : AppCompatActivity() {
                         // Only show the toast when a write actually happened
                         Toast.makeText(this@AuthSettingsActivity, "Setting saved. Restart app to apply.", Toast.LENGTH_SHORT).show()
                     }
+                    AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true)
                     btnCopy.visibility = View.VISIBLE
                     tvStatus.text = "Authentication enabled (restart app to apply)"
                 } else {
@@ -111,6 +112,7 @@ class AuthSettingsActivity : AppCompatActivity() {
                         Toast.makeText(this@AuthSettingsActivity, "Failed to save API key setting", Toast.LENGTH_LONG).show()
                         return@launch
                     }
+                    AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(false)
                     tvApiKey.text = "(none)"
                     btnCopy.visibility = View.GONE
                     tvStatus.text = "Authentication disabled (restart app to apply)"

--- a/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
@@ -97,7 +97,14 @@ class AuthSettingsActivity : AppCompatActivity() {
                 if (isChecked) {
                     val current = withContext(Dispatchers.IO) { configManager.readAuthConfig() }
                     if (!current.isEnabled) {
-                        val newKey = withContext(Dispatchers.IO) { configManager.generateAndSetApiKey() }
+                        // Key generation and preference write are in one IO block so
+                        // a lifecycle cancel between them cannot leave the preference
+                        // at true with no key in config.toml.
+                        val newKey = withContext(Dispatchers.IO) {
+                            val key = configManager.generateAndSetApiKey()
+                            if (key != null) AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true)
+                            key
+                        }
                         if (newKey == null) {
                             scheduleRefreshUI()
                             Toast.makeText(this@AuthSettingsActivity, "Failed to save API key", Toast.LENGTH_LONG).show()
@@ -106,18 +113,25 @@ class AuthSettingsActivity : AppCompatActivity() {
                         tvApiKey.text = newKey
                         // Only show the toast when a write actually happened
                         Toast.makeText(this@AuthSettingsActivity, "Setting saved. Restart app to apply.", Toast.LENGTH_SHORT).show()
+                    } else {
+                        withContext(Dispatchers.IO) { AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true) }
                     }
-                    withContext(Dispatchers.IO) { AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(true) }
                     btnCopy.visibility = View.VISIBLE
                     tvStatus.text = "Authentication enabled (restart app to apply)"
                 } else {
-                    val success = withContext(Dispatchers.IO) { configManager.clearApiKey() }
+                    // Key clear and preference write are in one IO block so a lifecycle
+                    // cancel between clearApiKey() and the preference write cannot leave
+                    // config.toml empty while the preference still reads true.
+                    val success = withContext(Dispatchers.IO) {
+                        val cleared = configManager.clearApiKey()
+                        if (cleared) AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(false)
+                        cleared
+                    }
                     if (!success) {
                         scheduleRefreshUI()
                         Toast.makeText(this@AuthSettingsActivity, "Failed to save API key setting", Toast.LENGTH_LONG).show()
                         return@launch
                     }
-                    withContext(Dispatchers.IO) { AWPreferences(this@AuthSettingsActivity).setDashboardAuthEnabled(false) }
                     tvApiKey.text = "(none)"
                     btnCopy.visibility = View.GONE
                     tvStatus.text = "Authentication disabled (restart app to apply)"

--- a/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
+++ b/mobile/src/main/java/net/activitywatch/android/DashboardAuth.kt
@@ -14,6 +14,11 @@ private val sectionHeaderPattern = Regex("""^\s*\[([^\]]+)]\s*(?:#.*)?$""")
 private val apiKeyPattern = Regex("""^\s*api_key\s*=\s*(['"])(.*?)\1\s*(?:#.*)?$""")
 
 fun ensureDashboardApiKey(context: Context): String {
+    // If the user explicitly disabled auth, respect that across restarts.
+    if (!AWPreferences(context).isDashboardAuthEnabled()) {
+        return ""
+    }
+
     val configFile = File(context.filesDir, CONFIG_FILE_NAME)
     val currentConfig = if (configFile.isFile) configFile.readText() else ""
     val existingApiKey = extractApiKey(currentConfig)


### PR DESCRIPTION
## Problem

Disabling dashboard authentication in Settings had no lasting effect. `ensureDashboardApiKey()` treated an absent `api_key` as "generate one", so clearing the key in `AuthSettingsActivity` was silently undone on the next app restart or cold boot.

## Root cause

`AuthSettingsActivity` called `configManager.clearApiKey()` (removes the key from `config.toml`) but there was no persistent record that the user *intended* auth to be off. On the next `BackgroundService.onStartCommand()` (or `MainActivity.onCreate()`), `ensureDashboardApiKey()` saw no key and generated a fresh one.

## Fix

Add a `dashboardAuthEnabled` boolean to `AWPreferences` (defaults to `true` so first-run key generation is unaffected):

- `AuthSettingsActivity` sets `AWPreferences.setDashboardAuthEnabled(false)` when the user disables auth, and `true` when re-enabled.
- `ensureDashboardApiKey()` returns early with `""` when the flag is `false`, preventing silent key re-generation.

## Changed files

| File | Change |
|------|--------|
| `AWPreferences.kt` | Add `isDashboardAuthEnabled()` / `setDashboardAuthEnabled()` |
| `DashboardAuth.kt` | Early return in `ensureDashboardApiKey()` when auth is disabled |
| `AuthSettingsActivity.kt` | Set preference flag when switch changes |

## Notes

- The default is `true`, so existing installs with auth enabled are unaffected.
- New installs get a key on first run as before.
- Users who already disabled auth before this fix will need to toggle it once to set the preference.

Identified by Codex review of #157 (see @ErikBjare's comment on that PR).