### PR TITLE
feat: add POST_NOTIFICATIONS permission and runtime request

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <meta-data android:name="com.samsung.android.vr.application.mode" android:value="dual" />
 

--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -37,6 +37,14 @@ class AWPreferences(context: Context) {
         sharedPreferences.edit().putBoolean("hasMigratedHostname", true).apply()
     }
 
+    fun hasRequestedNotificationPermission(): Boolean {
+        return sharedPreferences.getBoolean("hasRequestedNotificationPermission", false)
+    }
+
+    fun setNotificationPermissionRequested() {
+        sharedPreferences.edit().putBoolean("hasRequestedNotificationPermission", true).apply()
+    }
+
     // Sync is off by default; user must explicitly enable it once a sync directory
     // is configured (e.g. via Storage Access Framework).
     fun isSyncEnabled(): Boolean {

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -76,11 +76,14 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             return
         }
 
-        // Request POST_NOTIFICATIONS on Android 13+ so the foreground service notification
-        // is visible. Without this the OS silently suppresses the notification channel.
+        // Request POST_NOTIFICATIONS once on Android 13+ so the foreground service
+        // notification is visible without nagging users who decline the prompt.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
-                != PackageManager.PERMISSION_GRANTED) {
+                != PackageManager.PERMISSION_GRANTED &&
+            !prefs.hasRequestedNotificationPermission()
+        ) {
+            prefs.setNotificationPermissionRequested()
             requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
 

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -1,14 +1,19 @@
 package net.activitywatch.android
 
+import android.Manifest
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.navigation.NavigationView
@@ -29,6 +34,13 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var dashboardApiKey: String
+
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (!granted) {
+                Log.i(TAG, "POST_NOTIFICATIONS denied; foreground service notification will be suppressed on Android 13+")
+            }
+        }
 
     val version: String
         get() {
@@ -62,6 +74,14 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             startActivity(intent)
             finish()
             return
+        }
+
+        // Request POST_NOTIFICATIONS on Android 13+ so the foreground service notification
+        // is visible. Without this the OS silently suppresses the notification channel.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED) {
+            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
 
         // Set up UI


### PR DESCRIPTION
Closes part of #189.

## What

- Adds `POST_NOTIFICATIONS` to `AndroidManifest.xml`
- Adds a runtime permission request in `MainActivity` using `ActivityResultContracts.RequestPermission()`

## Why

On Android 13+ (API 33), the OS requires both a manifest declaration **and** a runtime grant for `POST_NOTIFICATIONS` before it will surface any notification — including the foreground service notification from `BackgroundService`. Without this, the notification channel exists but the notification is silently suppressed, which is why users (and the emulator recording) see no notification in the drawer.

The runtime request fires once at launch (after onboarding), is guarded by `Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU`, and is skipped if the permission is already granted. It's a no-op on Android < 13.

## Effect

Once granted, the "ActivityWatch Server / Server running in background" foreground notification will appear in the notification drawer while the app is backgrounded — which also makes it demonstrable for the Play Console `FOREGROUND_SERVICE_SPECIAL_USE` video requirement.