### PR TITLE
fix(widget): match Activity view startOfDay and add open-app button

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
+++ b/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
@@ -21,11 +21,12 @@ import com.jakewharton.threetenabp.AndroidThreeTen
 import org.json.JSONArray
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
+import org.threeten.bp.LocalTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 
 private const val TAG = "CategoryTimeWidget"
-private const val DEFAULT_START_OF_DAY_HOUR = 4  // matches aw-webui default "04:00"
+private val DEFAULT_START_OF_DAY = LocalTime.of(4, 0)  // matches aw-webui default "04:00"
 
 // Bar chart dimensions
 private const val BAR_WIDTH = 400
@@ -230,39 +231,42 @@ object CategoryTimeWidgetUpdater {
         }
 
         /**
-         * Fetch the startOfDay hour from the AW server settings API.
-         * Returns the hour component (0–23). Falls back to DEFAULT_START_OF_DAY_HOUR
-         * if the server is unavailable or the setting is unset, matching aw-webui's default.
+         * Fetch the startOfDay boundary from the AW server settings API.
+         * Falls back to DEFAULT_START_OF_DAY if the server is unavailable or the setting is unset.
          */
-        private fun fetchStartOfDayHour(): Int {
+        private fun fetchStartOfDay(): LocalTime {
             return try {
                 val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/startOfDay")
                 val conn = url.openConnection() as java.net.HttpURLConnection
                 conn.connectTimeout = 1000
                 conn.readTimeout = 1000
                 if (conn.responseCode == 200) {
-                    parseStartOfDayHour(conn.inputStream.bufferedReader().readText())
+                    parseStartOfDay(conn.inputStream.bufferedReader().readText())
                 } else {
                     Log.d(TAG, "startOfDay setting unavailable (HTTP ${conn.responseCode}), using default")
-                    DEFAULT_START_OF_DAY_HOUR
+                    DEFAULT_START_OF_DAY
                 }
             } catch (e: Exception) {
                 Log.d(TAG, "Could not fetch startOfDay setting, using default: ${e.message}")
-                DEFAULT_START_OF_DAY_HOUR
+                DEFAULT_START_OF_DAY
             }
         }
 
         /**
-         * Parse the server's startOfDay JSON response into an hour integer.
-         * Server returns null (unset) or a string like "04:00".
+         * Parse the server's startOfDay JSON response into a LocalTime.
+         * Server returns null (unset) or a quoted string like "04:00" or "04:30".
          */
-        private fun parseStartOfDayHour(response: String): Int {
+        internal fun parseStartOfDay(response: String): LocalTime {
             val v = response.trim()
             return when {
-                v == "null" -> DEFAULT_START_OF_DAY_HOUR
-                v.startsWith("\"") -> v.trim('"').split(":").firstOrNull()?.toIntOrNull()
-                    ?: DEFAULT_START_OF_DAY_HOUR
-                else -> v.toIntOrNull() ?: DEFAULT_START_OF_DAY_HOUR
+                v == "null" -> DEFAULT_START_OF_DAY
+                v.startsWith("\"") -> {
+                    val parts = v.trim('"').split(":")
+                    val hour = parts.getOrNull(0)?.toIntOrNull() ?: return DEFAULT_START_OF_DAY
+                    val minute = parts.getOrNull(1)?.toIntOrNull() ?: 0
+                    LocalTime.of(hour, minute)
+                }
+                else -> DEFAULT_START_OF_DAY
             }
         }
 
@@ -273,17 +277,19 @@ object CategoryTimeWidgetUpdater {
         private fun getCategoryTimesToday(ri: RustInterface): List<Pair<String, Long>> {
             val zone = ZoneId.systemDefault()
             val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-            val startOfDayHour = fetchStartOfDayHour()
+            val startOfDayTime = fetchStartOfDay()
 
-            // Match aw-webui's day boundary: if current hour < startOfDayHour we're still
-            // in the previous day's period (e.g. 3 AM with startOfDay=4 → "yesterday")
-            val now = LocalDateTime.now(zone)
-            val today = if (now.hour < startOfDayHour) LocalDate.now().minusDays(1) else LocalDate.now()
-            val startOfDay = today.atStartOfDay(zone).plusHours(startOfDayHour.toLong())
+            // Match aw-webui's day boundary: if current time is before startOfDay we're still
+            // in the previous day's period (e.g. 3:45 AM with startOfDay=04:00 → "yesterday")
+            val nowTime = LocalTime.now(zone)
+            val today = if (nowTime < startOfDayTime) LocalDate.now().minusDays(1) else LocalDate.now()
+            val startOfDay = today.atStartOfDay(zone)
+                .plusHours(startOfDayTime.hour.toLong())
+                .plusMinutes(startOfDayTime.minute.toLong())
             val endOfDay = startOfDay.plusDays(1)
 
             val timeperiod = "[\"${formatter.format(startOfDay)}/${formatter.format(endOfDay)}\"]"
-            Log.d(TAG, "Querying for timeperiod: $timeperiod (startOfDay=$startOfDayHour:00)")
+            Log.d(TAG, "Querying for timeperiod: $timeperiod (startOfDay=${startOfDayTime})")
 
             val result = ri.androidQuery(timeperiod)
             Log.d(TAG, "Query result length: ${result.length}")

--- a/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
+++ b/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
+import net.activitywatch.android.MainActivity
 import net.activitywatch.android.R
 import net.activitywatch.android.RustInterface
 import com.jakewharton.threetenabp.AndroidThreeTen
@@ -24,6 +25,7 @@ import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 
 private const val TAG = "CategoryTimeWidget"
+private const val DEFAULT_START_OF_DAY_HOUR = 4  // matches aw-webui default "04:00"
 
 // Bar chart dimensions
 private const val BAR_WIDTH = 400
@@ -133,7 +135,7 @@ object CategoryTimeWidgetUpdater {
                 views.setTextViewText(R.id.widget_minutes, "0")
             }
 
-            // Set up tap-to-refresh on the whole widget
+            // Single tap on widget body → refresh
             val refreshIntent = Intent(context, CategoryTimeWidgetProvider::class.java).apply {
                 action = ACTION_REFRESH
             }
@@ -144,6 +146,18 @@ object CategoryTimeWidgetUpdater {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
             views.setOnClickPendingIntent(R.id.widget_root, refreshPendingIntent)
+
+            // Open-app button → launch MainActivity
+            val launchIntent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val launchPendingIntent = PendingIntent.getActivity(
+                context,
+                2,
+                launchIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.widget_open_button, launchPendingIntent)
 
             // Ensure loading indicator is hidden
             views.setViewVisibility(R.id.widget_loading_indicator, View.GONE)
@@ -216,21 +230,61 @@ object CategoryTimeWidgetUpdater {
         }
 
         /**
-         * Query today's category times using androidQuery (same as MainActivity.onCreate)
+         * Fetch the startOfDay hour from the AW server settings API.
+         * Returns the hour component (0–23). Falls back to DEFAULT_START_OF_DAY_HOUR
+         * if the server is unavailable or the setting is unset, matching aw-webui's default.
+         */
+        private fun fetchStartOfDayHour(): Int {
+            return try {
+                val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/startOfDay")
+                val conn = url.openConnection() as java.net.HttpURLConnection
+                conn.connectTimeout = 1000
+                conn.readTimeout = 1000
+                if (conn.responseCode == 200) {
+                    parseStartOfDayHour(conn.inputStream.bufferedReader().readText())
+                } else {
+                    Log.d(TAG, "startOfDay setting unavailable (HTTP ${conn.responseCode}), using default")
+                    DEFAULT_START_OF_DAY_HOUR
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "Could not fetch startOfDay setting, using default: ${e.message}")
+                DEFAULT_START_OF_DAY_HOUR
+            }
+        }
+
+        /**
+         * Parse the server's startOfDay JSON response into an hour integer.
+         * Server returns null (unset) or a string like "04:00".
+         */
+        private fun parseStartOfDayHour(response: String): Int {
+            val v = response.trim()
+            return when {
+                v == "null" -> DEFAULT_START_OF_DAY_HOUR
+                v.startsWith("\"") -> v.trim('"').split(":").firstOrNull()?.toIntOrNull()
+                    ?: DEFAULT_START_OF_DAY_HOUR
+                else -> v.toIntOrNull() ?: DEFAULT_START_OF_DAY_HOUR
+            }
+        }
+
+        /**
+         * Query today's category times, using the same day boundary as aw-webui.
+         * Reads startOfDay from the AW server settings so the widget matches the Activity view.
          */
         private fun getCategoryTimesToday(ri: RustInterface): List<Pair<String, Long>> {
-            val today = LocalDate.now()
             val zone = ZoneId.systemDefault()
             val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+            val startOfDayHour = fetchStartOfDayHour()
 
-            val startOfDay = today.atStartOfDay(zone)
-            val endOfDay = today.plusDays(1).atStartOfDay(zone)
+            // Match aw-webui's day boundary: if current hour < startOfDayHour we're still
+            // in the previous day's period (e.g. 3 AM with startOfDay=4 → "yesterday")
+            val now = LocalDateTime.now(zone)
+            val today = if (now.hour < startOfDayHour) LocalDate.now().minusDays(1) else LocalDate.now()
+            val startOfDay = today.atStartOfDay(zone).plusHours(startOfDayHour.toLong())
+            val endOfDay = startOfDay.plusDays(1)
 
-            // Build time interval in the same format as RustInterface.test()
             val timeperiod = "[\"${formatter.format(startOfDay)}/${formatter.format(endOfDay)}\"]"
-            Log.d(TAG, "Querying for timeperiod: $timeperiod")
+            Log.d(TAG, "Querying for timeperiod: $timeperiod (startOfDay=$startOfDayHour:00)")
 
-            // Use androidQuery - the same function called in MainActivity.onCreate via RustInterface.test()
             val result = ri.androidQuery(timeperiod)
             Log.d(TAG, "Query result length: ${result.length}")
 

--- a/mobile/src/main/res/drawable/ic_open.xml
+++ b/mobile/src/main/res/drawable/ic_open.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,19H5V5h7V3H5C3.89,3 3,3.9 3,5v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
+</vector>

--- a/mobile/src/main/res/layout/widget_category_time.xml
+++ b/mobile/src/main/res/layout/widget_category_time.xml
@@ -15,14 +15,31 @@
         android:layout_weight="1"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/widget_header"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Screen time"
-            android:textColor="@color/widget_text_primary"
-            android:textSize="14sp"
-            android:textStyle="bold" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/widget_header"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Screen time"
+                android:textColor="@color/widget_text_primary"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <ImageView
+                android:id="@+id/widget_open_button"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/ic_open"
+                android:tint="@color/widget_text_muted"
+                android:contentDescription="Open ActivityWatch" />
+
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #197 (two issues from that report).

## 1. Widget time matches Activity view

**Root cause**: The widget queried from midnight (`today.atStartOfDay(zone)`) while aw-webui's Activity view uses `startOfDay` (default `"04:00"`) as the day boundary.

**Fix**: `getCategoryTimesToday` now reads `startOfDay` from the embedded server's settings API (`GET /api/0/settings/startOfDay`) before building the timeperiod — same source the Rust `androidQuery` already uses for category classes. Falls back to `4` (aw-webui default) if the server is unavailable or the setting is unset. Also mirrors aw-webui's pre-dawn logic: if the current hour is before `startOfDay`, the widget shows the previous calendar day's period (e.g. at 3 AM with `startOfDay=4`, "today" is yesterday 04:00–today 04:00).

## 2. Widget tap opens the app

**Fix**: Adds a small "open external" icon (`widget_open_button`) next to the "Screen time" header. Tapping it launches `MainActivity`. The main widget body keeps its existing single-tap-to-refresh behaviour.

## Changes
- `CategoryTimeWidgetUpdater.kt`: `fetchStartOfDayHour()` + `parseStartOfDayHour()` helpers; updated `getCategoryTimesToday`; launch `PendingIntent` wired to `widget_open_button`
- `widget_category_time.xml`: header row wrapped in horizontal `LinearLayout` with new `widget_open_button` `ImageView`
- `drawable/ic_open.xml`: Material "open in new" vector icon (new file)