### PR TITLE
feat(notify): add aw-notify support — activity-time threshold alerts

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -104,7 +104,26 @@ class BackgroundService : Service() {
         // Schedule event parsing
         scheduleEventParsing()
 
+        // Schedule activity-time notifications (aw-notify)
+        scheduleNotifyChecks()
+
         return START_STICKY
+    }
+
+    private fun scheduleNotifyChecks() {
+        val notifyRequest = androidx.work.PeriodicWorkRequest.Builder(
+            net.activitywatch.android.workers.NotifyWorker::class.java,
+            15, java.util.concurrent.TimeUnit.MINUTES
+        )
+            .addTag("NotifyWorker")
+            .build()
+
+        androidx.work.WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            "NotifyWorker",
+            androidx.work.ExistingPeriodicWorkPolicy.KEEP,
+            notifyRequest
+        )
+        Log.i(TAG, "Scheduled activity-time notification worker (every 15 minutes)")
     }
 
     private fun scheduleEventParsing() {

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -39,6 +39,9 @@ private val DEFAULT_ALERTS = listOf(
     CategoryAlert("YouTube",  "📺 YouTube", listOf(15, 30, 60)),
 )
 
+internal fun logicalDayDate(now: LocalDateTime, startOfDayHour: Int): LocalDate =
+    if (now.hour < startOfDayHour) now.toLocalDate().minusDays(1) else now.toLocalDate()
+
 class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
 
     override fun doWork(): Result {
@@ -56,8 +59,11 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
         }
 
         return try {
-            val categorySeconds = getCategorySecondsToday(ri)
-            checkAndNotify(categorySeconds)
+            val zone = ZoneId.systemDefault()
+            val startOfDayHour = fetchStartOfDayHour()
+            val now = LocalDateTime.now(zone)
+            val categorySeconds = getCategorySecondsToday(ri, now, zone, startOfDayHour)
+            checkAndNotify(categorySeconds, logicalDayDate(now, startOfDayHour))
             Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "Error checking notification thresholds", e)
@@ -65,14 +71,15 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
         }
     }
 
-    private fun getCategorySecondsToday(ri: RustInterface): Map<String?, Double> {
-        val zone = ZoneId.systemDefault()
+    private fun getCategorySecondsToday(
+        ri: RustInterface,
+        now: LocalDateTime,
+        zone: ZoneId,
+        startOfDayHour: Int,
+    ): Map<String?, Double> {
         val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-        val startOfDayHour = fetchStartOfDayHour()
-
-        val now = LocalDateTime.now(zone)
-        val today = if (now.hour < startOfDayHour) LocalDate.now().minusDays(1) else LocalDate.now()
-        val startOfDay = today.atStartOfDay(zone).plusHours(startOfDayHour.toLong())
+        val logicalDate = logicalDayDate(now, startOfDayHour)
+        val startOfDay = logicalDate.atStartOfDay(zone).plusHours(startOfDayHour.toLong())
         val endOfDay = startOfDay.plusDays(1)
 
         val timeperiod = "[\"${formatter.format(startOfDay)}/${formatter.format(endOfDay)}\"]"
@@ -111,18 +118,18 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
         return categories
     }
 
-    private fun checkAndNotify(categorySeconds: Map<String?, Double>) {
+    private fun checkAndNotify(categorySeconds: Map<String?, Double>, logicalDate: LocalDate) {
         ensureNotificationChannel()
 
         val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val today = LocalDate.now().toString()
+        val dayKey = logicalDate.toString()
 
         for (alert in DEFAULT_ALERTS) {
             val seconds = categorySeconds[alert.category] ?: 0.0
             val minutes = seconds / 60.0
 
-            // Suppress re-firing thresholds already triggered today
-            val prefKey = "triggered_${alert.category}_$today"
+            // Suppress re-firing thresholds already triggered this logical day
+            val prefKey = "triggered_${alert.category}_$dayKey"
             val alreadyTriggeredMinutes = prefs.getInt(prefKey, 0)
 
             // Find the highest newly-crossed threshold

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -1,0 +1,209 @@
+package net.activitywatch.android.workers
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.jakewharton.threetenabp.AndroidThreeTen
+import net.activitywatch.android.R
+import net.activitywatch.android.RustInterface
+import org.json.JSONArray
+import org.json.JSONException
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneId
+import org.threeten.bp.format.DateTimeFormatter
+
+private const val TAG = "NotifyWorker"
+private const val CHANNEL_ID = "aw_notify_channel"
+private const val PREFS_NAME = "aw_notify_prefs"
+private const val DEFAULT_START_OF_DAY_HOUR = 4
+
+// Mirrors desktop aw-notify CategoryAlert semantics.
+// positive=true → "Goal reached!" title; false → "Time spent"
+private data class CategoryAlert(
+    val category: String?,   // null = aggregate "All" time
+    val label: String,
+    val thresholdMinutes: List<Int>,
+    val positive: Boolean = false
+)
+
+private val DEFAULT_ALERTS = listOf(
+    CategoryAlert(null,       "All",        listOf(60, 120, 240, 360, 480)),
+    CategoryAlert("Work",     "💼 Work",    listOf(15, 30, 60, 120, 240), positive = true),
+    CategoryAlert("Twitter",  "🐦 Twitter", listOf(15, 30, 60)),
+    CategoryAlert("YouTube",  "📺 YouTube", listOf(15, 30, 60)),
+)
+
+class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+
+    override fun doWork(): Result {
+        Log.i(TAG, "Starting category time notification check")
+        AndroidThreeTen.init(applicationContext)
+
+        val ri = RustInterface(applicationContext)
+
+        // Check server availability before querying
+        try {
+            ri.getBucketsJSON()
+        } catch (e: JSONException) {
+            Log.w(TAG, "Server not reachable; retrying later")
+            return Result.retry()
+        }
+
+        return try {
+            val categorySeconds = getCategorySecondsToday(ri)
+            checkAndNotify(categorySeconds)
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking notification thresholds", e)
+            Result.retry()
+        }
+    }
+
+    private fun getCategorySecondsToday(ri: RustInterface): Map<String?, Double> {
+        val zone = ZoneId.systemDefault()
+        val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+        val startOfDayHour = fetchStartOfDayHour()
+
+        val now = LocalDateTime.now(zone)
+        val today = if (now.hour < startOfDayHour) LocalDate.now().minusDays(1) else LocalDate.now()
+        val startOfDay = today.atStartOfDay(zone).plusHours(startOfDayHour.toLong())
+        val endOfDay = startOfDay.plusDays(1)
+
+        val timeperiod = "[\"${formatter.format(startOfDay)}/${formatter.format(endOfDay)}\"]"
+        Log.d(TAG, "Querying timeperiod: $timeperiod")
+
+        return parseCategorySeconds(ri.androidQuery(timeperiod))
+    }
+
+    private fun parseCategorySeconds(jsonResult: String): Map<String?, Double> {
+        val categories = mutableMapOf<String?, Double>()
+        var totalDuration = 0.0
+
+        try {
+            val resultArray = JSONArray(jsonResult)
+            if (resultArray.length() == 0) return emptyMap()
+
+            val periodResult = resultArray.getJSONObject(0)
+            val catEvents = periodResult.optJSONArray("cat_events") ?: return emptyMap()
+
+            for (i in 0 until catEvents.length()) {
+                val event = catEvents.getJSONObject(i)
+                val duration = event.optDouble("duration", 0.0)
+                val data = event.optJSONObject("data") ?: continue
+                val categoryArray = data.optJSONArray("\$category")
+                if (categoryArray == null || categoryArray.length() == 0) continue
+
+                val topLevel = categoryArray.optString(0, "Uncategorized")
+                categories[topLevel] = (categories[topLevel] ?: 0.0) + duration
+                totalDuration += duration
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing category JSON", e)
+        }
+
+        categories[null] = totalDuration  // aggregate "All" key
+        return categories
+    }
+
+    private fun checkAndNotify(categorySeconds: Map<String?, Double>) {
+        ensureNotificationChannel()
+
+        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val today = LocalDate.now().toString()
+
+        for (alert in DEFAULT_ALERTS) {
+            val seconds = categorySeconds[alert.category] ?: 0.0
+            val minutes = seconds / 60.0
+
+            // Suppress re-firing thresholds already triggered today
+            val prefKey = "triggered_${alert.category}_$today"
+            val alreadyTriggeredMinutes = prefs.getInt(prefKey, 0)
+
+            // Find the highest newly-crossed threshold
+            val nextThreshold = alert.thresholdMinutes
+                .filter { it > alreadyTriggeredMinutes && minutes >= it }
+                .maxOrNull() ?: continue
+
+            sendNotification(alert, nextThreshold, minutes)
+            prefs.edit().putInt(prefKey, nextThreshold).apply()
+            Log.i(TAG, "Fired alert: ${alert.label} at ${nextThreshold}min (actual: ${minutes.toInt()}min)")
+        }
+    }
+
+    private fun sendNotification(alert: CategoryAlert, thresholdMinutes: Int, actualMinutes: Double) {
+        val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val thresholdStr = formatDuration(thresholdMinutes)
+        val actualStr = formatDuration(actualMinutes.toInt())
+        val body = "${alert.label}: $thresholdStr" +
+            if (thresholdStr != actualStr) "  ($actualStr)" else ""
+
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle(if (alert.positive) "Goal reached!" else "Time spent")
+            .setContentText(body)
+            .setSmallIcon(R.mipmap.aw_launcher_round)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+
+        // Stable ID per alert so notifications update in-place rather than stacking
+        val notifId = 1000 + (alert.category?.hashCode() ?: 0).and(0xFFFF)
+        nm.notify(notifId, notification)
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Activity Time Alerts",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Alerts when you reach time thresholds for activities"
+            }
+            (applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .createNotificationChannel(channel)
+        }
+    }
+
+    private fun fetchStartOfDayHour(): Int {
+        return try {
+            val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/startOfDay")
+            val conn = url.openConnection() as java.net.HttpURLConnection
+            conn.connectTimeout = 1_000
+            conn.readTimeout = 1_000
+            if (conn.responseCode == 200) {
+                parseStartOfDayHour(conn.inputStream.bufferedReader().readText())
+            } else {
+                DEFAULT_START_OF_DAY_HOUR
+            }
+        } catch (e: Exception) {
+            DEFAULT_START_OF_DAY_HOUR
+        }
+    }
+
+    private fun parseStartOfDayHour(response: String): Int {
+        val v = response.trim()
+        return when {
+            v == "null" -> DEFAULT_START_OF_DAY_HOUR
+            v.startsWith("\"") -> v.trim('"').split(":").firstOrNull()?.toIntOrNull()
+                ?: DEFAULT_START_OF_DAY_HOUR
+            else -> v.toIntOrNull() ?: DEFAULT_START_OF_DAY_HOUR
+        }
+    }
+
+    private fun formatDuration(minutes: Int): String {
+        val h = minutes / 60
+        val m = minutes % 60
+        return when {
+            h > 0 && m > 0 -> "${h}h ${m}m"
+            h > 0 -> "${h}h"
+            else -> "${m}m"
+        }
+    }
+}

--- a/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
@@ -1,0 +1,22 @@
+package net.activitywatch.android.workers
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+
+class NotifyWorkerTest {
+    @Test
+    fun logicalDayDate_usesPreviousDateBeforeConfiguredBoundary() {
+        val now = LocalDateTime.of(2026, 7, 24, 3, 59)
+
+        assertEquals(LocalDate.of(2026, 7, 23), logicalDayDate(now, 4))
+    }
+
+    @Test
+    fun logicalDayDate_usesCurrentDateAtConfiguredBoundary() {
+        val now = LocalDateTime.of(2026, 7, 24, 4, 0)
+
+        assertEquals(LocalDate.of(2026, 7, 24), logicalDayDate(now, 4))
+    }
+}


### PR DESCRIPTION
Closes #196.

## What

Adds `aw-notify` support on Android: a WorkManager periodic task evaluates
daily category-time thresholds and fires user-visible notifications when they
are crossed, mirroring the behavior of the desktop
[aw-notify](https://github.com/ActivityWatch/aw-notify) tool.

## New files

**`workers/NotifyWorker.kt`** — the core worker:
- Runs every 15 minutes via WorkManager `PeriodicWorkRequest` (Android's
  minimum interval; coarse but appropriate for daily-budget alerts).
- Queries `RustInterface.androidQuery()` for today's category times, using
  the same `startOfDay` logic as the widget (fetched from the local AW
  server, falls back to 04:00 to match aw-webui's default).
- Checks each `CategoryAlert` against its threshold list.  Only the
  highest newly-crossed threshold fires per check, to avoid notification
  bursts when the worker wakes up after a long gap.
- Duplicate-suppression via `SharedPreferences` keyed by
  `triggered_{category}_{date}` — thresholds reset automatically at the
  `startOfDay` boundary because the key rolls with the date string.
- Posts via `NotificationCompat` on a separate `aw_notify_channel`
  (importance = DEFAULT) so users can mute activity alerts without losing
  the foreground-service notification.

**`BackgroundService.kt`** — `scheduleNotifyChecks()` added to
`onStartCommand`, enqueues the worker with `KEEP` policy (no duplicate
workers on service restart).

## Default alerts (matching aw-notify desktop defaults)

| Category | Label | Thresholds |
|---|---|---|
| All | All | 1h · 2h · 4h · 6h · 8h |
| Work | 💼 Work | 15m · 30m · 1h · 2h · 4h (positive — "Goal reached!") |
| Twitter | 🐦 Twitter | 15m · 30m · 1h |
| YouTube | 📺 YouTube | 15m · 30m · 1h |

## Design decisions

- **Re-use over re-implement**: the same `androidQuery()` + `startOfDay` fetch
  that the widget uses, not a new HTTP call.  The notification logic is a
  Kotlin port of `CategoryAlert` from the Python daemon.
- **WorkManager not a daemon**: Android background-execution limits make a
  continuous polling thread unviable.  The 15-minute granularity is acceptable
  for daily-budget nudges and matches Android best practice.
- **No user config in this slice**: alerts are hardcoded to the desktop
  defaults. A follow-up issue can add preferences for custom categories and
  thresholds.
- **Quiet hours / DnD**: delegated to the OS — the `aw_notify_channel` respects
  system Do-Not-Disturb automatically; no app-layer quiet-hours in this MVP.

## Testing

The `NotifyWorker` can be triggered manually for a quick smoke-test:

```kotlin
WorkManager.getInstance(context)
    .enqueue(OneTimeWorkRequestBuilder<NotifyWorker>().build())
```

Or via adb:
```bash
adb shell am broadcast -a androidx.work.diagnostics.REQUEST_DIAGNOSTICS \
  --receiver-include-background -n net.activitywatch.android/.workers.NotifyWorker
```

Automated tests for the threshold logic are out of scope for this MVP but would
be a natural next step.