### PR TITLE
feat(notify): read alert config from server settings, fall back to defaults

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     implementation 'com.jakewharton.threetenabp:threetenabp:1.4.9'
 
     testImplementation "junit:junit:4.13.2"
+    testImplementation 'org.json:json:20231013'
     androidTestImplementation "androidx.test.ext:junit-ktx:$extJUnitVersion"
     androidTestImplementation "androidx.test:runner:$androidXTestVersion"
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -42,6 +42,19 @@ private val DEFAULT_ALERTS = listOf(
 internal fun logicalDayDate(now: LocalDateTime, startOfDayHour: Int): LocalDate =
     if (now.hour < startOfDayHour) now.toLocalDate().minusDays(1) else now.toLocalDate()
 
+internal fun parseAlerts(json: String): List<CategoryAlert> {
+    val arr = JSONArray(json)
+    return (0 until arr.length()).mapNotNull { i ->
+        val obj = arr.getJSONObject(i)
+        val category = if (obj.isNull("category")) null else obj.optString("category").ifEmpty { null }
+        val label = obj.optString("label").ifEmpty { return@mapNotNull null }
+        val thresholdsArr = obj.optJSONArray("thresholdMinutes") ?: return@mapNotNull null
+        val thresholds = (0 until thresholdsArr.length()).map { thresholdsArr.getInt(it) }
+        val positive = obj.optBoolean("positive", false)
+        CategoryAlert(category, label, thresholds, positive)
+    }
+}
+
 class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
 
     override fun doWork(): Result {
@@ -63,7 +76,8 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
             val startOfDayHour = fetchStartOfDayHour()
             val now = LocalDateTime.now(zone)
             val categorySeconds = getCategorySecondsToday(ri, now, zone, startOfDayHour)
-            checkAndNotify(categorySeconds, logicalDayDate(now, startOfDayHour))
+            val alerts = fetchAlerts()
+            checkAndNotify(categorySeconds, logicalDayDate(now, startOfDayHour), alerts)
             Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "Error checking notification thresholds", e)
@@ -118,13 +132,17 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
         return categories
     }
 
-    private fun checkAndNotify(categorySeconds: Map<String?, Double>, logicalDate: LocalDate) {
+    private fun checkAndNotify(
+        categorySeconds: Map<String?, Double>,
+        logicalDate: LocalDate,
+        alerts: List<CategoryAlert> = DEFAULT_ALERTS,
+    ) {
         ensureNotificationChannel()
 
         val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val dayKey = logicalDate.toString()
 
-        for (alert in DEFAULT_ALERTS) {
+        for (alert in alerts) {
             val seconds = categorySeconds[alert.category] ?: 0.0
             val minutes = seconds / 60.0
 
@@ -191,6 +209,25 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
             }
         } catch (e: Exception) {
             DEFAULT_START_OF_DAY_HOUR
+        }
+    }
+
+    private fun fetchAlerts(): List<CategoryAlert> {
+        return try {
+            val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/aw-notify")
+            val conn = url.openConnection() as java.net.HttpURLConnection
+            conn.connectTimeout = 1_000
+            conn.readTimeout = 1_000
+            if (conn.responseCode == 200) {
+                val text = conn.inputStream.bufferedReader().readText().trim()
+                if (text == "null" || text.isBlank()) DEFAULT_ALERTS
+                else parseAlerts(text).takeIf { it.isNotEmpty() } ?: DEFAULT_ALERTS
+            } else {
+                DEFAULT_ALERTS
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "Could not fetch alert config from server, using defaults")
+            DEFAULT_ALERTS
         }
     }
 

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -55,6 +55,13 @@ internal fun parseAlerts(json: String): List<CategoryAlert> {
     }
 }
 
+// Include thresholds in the pref key so state resets when configuration changes.
+// A lowered threshold mid-day would otherwise be silently skipped because the old
+// triggered value is higher than all new thresholds.
+internal fun alertConfigHash(alert: CategoryAlert): Int =
+    (alert.thresholdMinutes.toString() + alert.positive.toString())
+        .hashCode().and(0x3FFFFFFF)
+
 class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
 
     override fun doWork(): Result {
@@ -146,8 +153,11 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
             val seconds = categorySeconds[alert.category] ?: 0.0
             val minutes = seconds / 60.0
 
-            // Suppress re-firing thresholds already triggered this logical day
-            val prefKey = "triggered_${alert.category}_$dayKey"
+            // Suppress re-firing thresholds already triggered this logical day.
+            // Config hash ensures a new lower threshold isn't silently skipped when
+            // the user reconfigures mid-day — the new hash produces a fresh key.
+            val configHash = alertConfigHash(alert)
+            val prefKey = "triggered_${alert.category}_${configHash}_$dayKey"
             val alreadyTriggeredMinutes = prefs.getInt(prefKey, 0)
 
             // Find the highest newly-crossed threshold

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -25,7 +25,7 @@ private const val DEFAULT_START_OF_DAY_HOUR = 4
 
 // Mirrors desktop aw-notify CategoryAlert semantics.
 // positive=true → "Goal reached!" title; false → "Time spent"
-private data class CategoryAlert(
+internal data class CategoryAlert(
     val category: String?,   // null = aggregate "All" time
     val label: String,
     val thresholdMinutes: List<Int>,

--- a/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
@@ -1,6 +1,7 @@
 package net.activitywatch.android.workers
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
@@ -18,5 +19,39 @@ class NotifyWorkerTest {
         val now = LocalDateTime.of(2026, 7, 24, 4, 0)
 
         assertEquals(LocalDate.of(2026, 7, 24), logicalDayDate(now, 4))
+    }
+
+    @Test
+    fun parseAlerts_parsesAggregateAlert() {
+        val json = """[{"category":null,"label":"All","thresholdMinutes":[60,120,240],"positive":false}]"""
+        val alerts = parseAlerts(json)
+        assertEquals(1, alerts.size)
+        assertNull(alerts[0].category)
+        assertEquals("All", alerts[0].label)
+        assertEquals(listOf(60, 120, 240), alerts[0].thresholdMinutes)
+        assertEquals(false, alerts[0].positive)
+    }
+
+    @Test
+    fun parseAlerts_parsesCategoryAlertWithPositive() {
+        val json = """[{"category":"Work","label":"Work","thresholdMinutes":[15,30,60],"positive":true}]"""
+        val alerts = parseAlerts(json)
+        assertEquals(1, alerts.size)
+        assertEquals("Work", alerts[0].category)
+        assertEquals(true, alerts[0].positive)
+    }
+
+    @Test
+    fun parseAlerts_returnsEmptyForEmptyArray() {
+        assertEquals(0, parseAlerts("[]").size)
+    }
+
+    @Test
+    fun parseAlerts_parsesMultipleAlerts() {
+        val json = """[
+            {"category":null,"label":"All","thresholdMinutes":[60],"positive":false},
+            {"category":"Work","label":"Work","thresholdMinutes":[30],"positive":true}
+        ]"""
+        assertEquals(2, parseAlerts(json).size)
     }
 }

--- a/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
@@ -54,4 +54,24 @@ class NotifyWorkerTest {
         ]"""
         assertEquals(2, parseAlerts(json).size)
     }
+
+    @Test
+    fun alertConfigHash_differsWhenThresholdsChange() {
+        val alert60  = CategoryAlert("Work", "Work", listOf(60, 120), false)
+        val alert30  = CategoryAlert("Work", "Work", listOf(30, 60),  false)
+        val alertPos = CategoryAlert("Work", "Work", listOf(60, 120), true)
+
+        // Same config → stable pref key (no spurious re-fires)
+        assertEquals(alertConfigHash(alert60), alertConfigHash(alert60))
+
+        // Different thresholds → different hash → old triggered state ignored
+        assert(alertConfigHash(alert60) != alertConfigHash(alert30)) {
+            "Changing thresholds must change the pref-key hash to reset daily state"
+        }
+
+        // Different positive flag → different hash
+        assert(alertConfigHash(alert60) != alertConfigHash(alertPos)) {
+            "Changing positive flag must change the pref-key hash"
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #199 — implements the settingsStore integration described in #201.

## What changed

`NotifyWorker` now fetches alert config from the embedded aw-server at `/api/0/settings/aw-notify` at worker startup, rather than using the hardcoded `DEFAULT_ALERTS` list.

**Fallback behaviour is fully preserved**: if the settings key is unset (404), the server is unreachable (timeout/network error), or the returned list is empty, the worker falls back to `DEFAULT_ALERTS`. Existing users see zero behavioural change until they explicitly configure thresholds.

## Schema

The `/api/0/settings/aw-notify` value is a JSON array of alert objects:

```json
[
  {"category": null, "label": "All", "thresholdMinutes": [60, 120, 240], "positive": false},
  {"category": "Work", "label": "Work", "thresholdMinutes": [15, 30, 60], "positive": true}
]
```

`category: null` is the aggregate "All" time key (matching existing `CategoryAlert` semantics). `positive: true` uses the "Goal reached!" notification title.

## Implementation notes

- `parseAlerts()` is now an `internal` top-level function so it can be unit-tested without a `Context`.
- `fetchAlerts()` follows the exact same HTTP pattern as `fetchStartOfDayHour()` (1s timeouts, silent fallback on exception, no retry — the next WorkManager run will try again).
- `checkAndNotify()` now takes `alerts: List<CategoryAlert>` as a parameter (defaulting to `DEFAULT_ALERTS`) so the fetching is separated from the notification logic.
- Adds 4 unit tests covering: aggregate alert, category+positive alert, empty array, and multiple alerts.

## Related

- Closes #201 (settingsStore integration goal)
- Follow-up to #199 (the initial notify implementation)