### PR TITLE
feat(sync): add SyncSettingsActivity — enable/disable toggle + SAF directory picker

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -57,6 +57,12 @@
             android:configChanges="orientation"
             android:exported="false"/>
 
+        <activity
+            android:name=".SyncSettingsActivity"
+            android:screenOrientation="portrait"
+            android:configChanges="orientation"
+            android:exported="false"/>
+
         <receiver
             android:name=".watcher.AlarmReceiver"
             android:enabled="true"

--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -55,6 +55,16 @@ class AWPreferences(context: Context) {
         sharedPreferences.edit().putBoolean("syncEnabled", enabled).apply()
     }
 
+    // SAF URI for the user-chosen sync directory (content:// URI string, or null if not configured).
+    // The URI has persisted permission granted via contentResolver.takePersistableUriPermission().
+    fun getSyncDirUri(): String? {
+        return sharedPreferences.getString("syncDirUri", null)
+    }
+
+    fun setSyncDirUri(uri: String?) {
+        sharedPreferences.edit().putString("syncDirUri", uri).apply()
+    }
+
     // Dashboard authentication. Defaults to true so first-run gets a key generated
     // automatically. Set to false when the user explicitly disables auth in settings;
     // ensureDashboardApiKey() checks this before generating a new key so that the

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -34,6 +34,11 @@ class BackgroundService : Service() {
     private lateinit var syncScheduler: SyncScheduler
     private lateinit var rustInterface: RustInterface
 
+    // Becomes true after the first full onStartCommand() completes (server started,
+    // workers scheduled, etc.). Guards against ACTION_SYNC_ENABLED_CHANGED skipping
+    // full initialization when Android kills and recreates the service.
+    private var isFullyStarted = false
+
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "BackgroundService created")
@@ -57,7 +62,12 @@ class BackgroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == ACTION_SYNC_ENABLED_CHANGED) {
+        // Only short-circuit for the scheduler-toggle action when the service is already
+        // fully running. If Android killed the service while SyncSettingsActivity was open,
+        // the toggle re-creates the service with this action as its first command — in that
+        // case isFullyStarted is false and we fall through to run the complete startup path
+        // (server start, event parsing, notify scheduling) before honouring the toggle.
+        if (intent?.action == ACTION_SYNC_ENABLED_CHANGED && isFullyStarted) {
             val enabled = AWPreferences(this).isSyncEnabled()
             Log.i(TAG, "Sync enabled changed to $enabled; ${if (enabled) "starting" else "stopping"} scheduler")
             if (enabled) syncScheduler.start() else syncScheduler.stop()
@@ -120,6 +130,7 @@ class BackgroundService : Service() {
         // Schedule activity-time notifications (aw-notify)
         scheduleNotifyChecks()
 
+        isFullyStarted = true
         return START_STICKY
     }
 

--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -25,6 +25,12 @@ private const val NOTIFICATION_ID = 1
 
 class BackgroundService : Service() {
 
+    companion object {
+        // Sent by SyncSettingsActivity when the user toggles sync on/off so the
+        // running scheduler reflects the new setting immediately without a restart.
+        const val ACTION_SYNC_ENABLED_CHANGED = "net.activitywatch.android.SYNC_ENABLED_CHANGED"
+    }
+
     private lateinit var syncScheduler: SyncScheduler
     private lateinit var rustInterface: RustInterface
 
@@ -51,6 +57,13 @@ class BackgroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_SYNC_ENABLED_CHANGED) {
+            val enabled = AWPreferences(this).isSyncEnabled()
+            Log.i(TAG, "Sync enabled changed to $enabled; ${if (enabled) "starting" else "stopping"} scheduler")
+            if (enabled) syncScheduler.start() else syncScheduler.stop()
+            return START_STICKY
+        }
+
         Log.i(TAG, "BackgroundService started")
 
         // Ensure the API key is written to config.toml before the server reads it.

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -149,6 +149,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                 startActivity(Intent(this, AuthSettingsActivity::class.java))
                 true
             }
+            R.id.action_sync_settings -> {
+                startActivity(Intent(this, SyncSettingsActivity::class.java))
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -56,16 +56,19 @@ class SyncSettingsActivity : AppCompatActivity() {
                     return@registerForActivityResult
                 }
 
-                // New grant secured — now release the old one to stay within Android's bounded
-                // persisted-grant allowance.
+                // New grant secured — now release a different old URI to stay within Android's
+                // bounded persisted-grant allowance. Reselecting the current directory must not
+                // release the grant we just took for that same URI.
                 val oldUriStr = prefs.getSyncDirUri()
                 if (oldUriStr != null) {
-                    try {
-                        val oldUri = Uri.parse(oldUriStr)
-                        val releaseFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        contentResolver.releasePersistableUriPermission(oldUri, releaseFlags)
-                    } catch (e: SecurityException) {
-                        Log.w(TAG, "Could not release old URI grant: ${e.message}")
+                    val oldUri = Uri.parse(oldUriStr)
+                    if (oldUri != uri) {
+                        try {
+                            val releaseFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            contentResolver.releasePersistableUriPermission(oldUri, releaseFlags)
+                        } catch (e: SecurityException) {
+                            Log.w(TAG, "Could not release old URI grant: ${e.message}")
+                        }
                     }
                 }
 

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -1,0 +1,116 @@
+package net.activitywatch.android
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.DocumentsContract
+import android.view.MenuItem
+import android.widget.Button
+import android.widget.CompoundButton
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.switchmaterial.SwitchMaterial
+
+class SyncSettingsActivity : AppCompatActivity() {
+
+    private lateinit var prefs: AWPreferences
+
+    private lateinit var switchSyncEnabled: SwitchMaterial
+    private lateinit var tvSyncDirStatus: TextView
+    private lateinit var btnChooseDir: Button
+
+    // Guards against the switch listener firing when we set isChecked programmatically
+    private var isUpdatingSwitch = false
+
+    private val openDocumentTree =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val uri: Uri = result.data?.data ?: return@registerForActivityResult
+                // Take persistable permission so we can access this URI after reboot
+                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                contentResolver.takePersistableUriPermission(uri, flags)
+                prefs.setSyncDirUri(uri.toString())
+                updateSyncDirStatus()
+                Toast.makeText(this, "Sync directory configured", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_sync_settings)
+
+        supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            title = "Sync Settings"
+        }
+
+        prefs = AWPreferences(this)
+
+        switchSyncEnabled = findViewById(R.id.switch_sync_enabled)
+        tvSyncDirStatus = findViewById(R.id.tv_sync_dir_status)
+        btnChooseDir = findViewById(R.id.btn_choose_sync_dir)
+
+        refreshUI()
+
+        switchSyncEnabled.setOnCheckedChangeListener { _: CompoundButton, isChecked: Boolean ->
+            if (isUpdatingSwitch) return@setOnCheckedChangeListener
+            prefs.setSyncEnabled(isChecked)
+        }
+
+        btnChooseDir.setOnClickListener {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                // Suggest a sensible starting location (Downloads if available)
+                putExtra(DocumentsContract.EXTRA_INITIAL_URI, Uri.parse("content://com.android.externalstorage.documents/document/primary%3ADownloads"))
+            }
+            openDocumentTree.launch(intent)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::prefs.isInitialized) refreshUI()
+    }
+
+    private fun refreshUI() {
+        isUpdatingSwitch = true
+        switchSyncEnabled.isChecked = prefs.isSyncEnabled()
+        isUpdatingSwitch = false
+        updateSyncDirStatus()
+        updateStatus()
+    }
+
+    private fun updateSyncDirStatus() {
+        val uriStr = prefs.getSyncDirUri()
+        tvSyncDirStatus.text = if (uriStr != null) {
+            val displayName = resolveDisplayName(Uri.parse(uriStr)) ?: uriStr
+            "Directory: $displayName"
+        } else {
+            "No sync directory configured. Tap \"Choose Directory\" to select one accessible to Syncthing or other sync tools."
+        }
+    }
+
+    // Resolve a content:// tree URI to a human-readable path like "Downloads" or "Documents/aw-sync"
+    private fun resolveDisplayName(uri: Uri): String? {
+        return try {
+            val docUri = DocumentsContract.buildDocumentUriUsingTree(uri, DocumentsContract.getTreeDocumentId(uri))
+            contentResolver.query(docUri, arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) cursor.getString(0) else null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -38,16 +38,22 @@ class SyncSettingsActivity : AppCompatActivity() {
                 val grantedFlags = result.data?.flags ?: 0
                 val persistableFlags = grantedFlags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
 
+                // If no persistable flags were granted at all, the URI won't survive a reboot.
+                // Abort so the previously-working directory config remains intact.
+                if (persistableFlags == 0) {
+                    Log.w(TAG, "Document provider granted no persistable flags — aborting directory update")
+                    Toast.makeText(this, "Could not secure persistent access to selected directory", Toast.LENGTH_SHORT).show()
+                    return@registerForActivityResult
+                }
+
                 // Take the NEW grant BEFORE releasing the old one. If takePersistableUriPermission
                 // fails, we abort early so the previously-working grant remains intact.
-                if (persistableFlags != 0) {
-                    try {
-                        contentResolver.takePersistableUriPermission(uri, persistableFlags)
-                    } catch (e: SecurityException) {
-                        Log.w(TAG, "Could not take persistable permission: ${e.message}")
-                        Toast.makeText(this, "Could not secure persistent access to selected directory", Toast.LENGTH_SHORT).show()
-                        return@registerForActivityResult
-                    }
+                try {
+                    contentResolver.takePersistableUriPermission(uri, persistableFlags)
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "Could not take persistable permission: ${e.message}")
+                    Toast.makeText(this, "Could not secure persistent access to selected directory", Toast.LENGTH_SHORT).show()
+                    return@registerForActivityResult
                 }
 
                 // New grant secured — now release the old one to stay within Android's bounded

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -33,8 +33,25 @@ class SyncSettingsActivity : AppCompatActivity() {
             if (result.resultCode == Activity.RESULT_OK) {
                 val uri: Uri = result.data?.data ?: return@registerForActivityResult
 
-                // Release the old grant before persisting the new one to avoid
-                // accumulating stale grants against Android's bounded persisted-grant allowance.
+                // Only persist the subset of flags the provider actually granted — passing
+                // modes the provider didn't offer causes SecurityException.
+                val grantedFlags = result.data?.flags ?: 0
+                val persistableFlags = grantedFlags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+
+                // Take the NEW grant BEFORE releasing the old one. If takePersistableUriPermission
+                // fails, we abort early so the previously-working grant remains intact.
+                if (persistableFlags != 0) {
+                    try {
+                        contentResolver.takePersistableUriPermission(uri, persistableFlags)
+                    } catch (e: SecurityException) {
+                        Log.w(TAG, "Could not take persistable permission: ${e.message}")
+                        Toast.makeText(this, "Could not secure persistent access to selected directory", Toast.LENGTH_SHORT).show()
+                        return@registerForActivityResult
+                    }
+                }
+
+                // New grant secured — now release the old one to stay within Android's bounded
+                // persisted-grant allowance.
                 val oldUriStr = prefs.getSyncDirUri()
                 if (oldUriStr != null) {
                     try {
@@ -43,18 +60,6 @@ class SyncSettingsActivity : AppCompatActivity() {
                         contentResolver.releasePersistableUriPermission(oldUri, releaseFlags)
                     } catch (e: SecurityException) {
                         Log.w(TAG, "Could not release old URI grant: ${e.message}")
-                    }
-                }
-
-                // Only persist the subset of flags the provider actually granted — passing
-                // modes the provider didn't offer causes SecurityException.
-                val grantedFlags = result.data?.flags ?: 0
-                val persistableFlags = grantedFlags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-                if (persistableFlags != 0) {
-                    try {
-                        contentResolver.takePersistableUriPermission(uri, persistableFlags)
-                    } catch (e: SecurityException) {
-                        Log.w(TAG, "Could not take persistable permission: ${e.message}")
                     }
                 }
 

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -79,7 +79,6 @@ class SyncSettingsActivity : AppCompatActivity() {
         switchSyncEnabled.isChecked = prefs.isSyncEnabled()
         isUpdatingSwitch = false
         updateSyncDirStatus()
-        updateStatus()
     }
 
     private fun updateSyncDirStatus() {

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
+import android.util.Log
 import android.view.MenuItem
 import android.widget.Button
 import android.widget.CompoundButton
@@ -13,6 +14,8 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.switchmaterial.SwitchMaterial
+
+private const val TAG = "SyncSettingsActivity"
 
 class SyncSettingsActivity : AppCompatActivity() {
 
@@ -29,9 +32,32 @@ class SyncSettingsActivity : AppCompatActivity() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val uri: Uri = result.data?.data ?: return@registerForActivityResult
-                // Take persistable permission so we can access this URI after reboot
-                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                contentResolver.takePersistableUriPermission(uri, flags)
+
+                // Release the old grant before persisting the new one to avoid
+                // accumulating stale grants against Android's bounded persisted-grant allowance.
+                val oldUriStr = prefs.getSyncDirUri()
+                if (oldUriStr != null) {
+                    try {
+                        val oldUri = Uri.parse(oldUriStr)
+                        val releaseFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        contentResolver.releasePersistableUriPermission(oldUri, releaseFlags)
+                    } catch (e: SecurityException) {
+                        Log.w(TAG, "Could not release old URI grant: ${e.message}")
+                    }
+                }
+
+                // Only persist the subset of flags the provider actually granted — passing
+                // modes the provider didn't offer causes SecurityException.
+                val grantedFlags = result.data?.flags ?: 0
+                val persistableFlags = grantedFlags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                if (persistableFlags != 0) {
+                    try {
+                        contentResolver.takePersistableUriPermission(uri, persistableFlags)
+                    } catch (e: SecurityException) {
+                        Log.w(TAG, "Could not take persistable permission: ${e.message}")
+                    }
+                }
+
                 prefs.setSyncDirUri(uri.toString())
                 updateSyncDirStatus()
                 Toast.makeText(this, "Sync directory configured", Toast.LENGTH_SHORT).show()
@@ -58,6 +84,11 @@ class SyncSettingsActivity : AppCompatActivity() {
         switchSyncEnabled.setOnCheckedChangeListener { _: CompoundButton, isChecked: Boolean ->
             if (isUpdatingSwitch) return@setOnCheckedChangeListener
             prefs.setSyncEnabled(isChecked)
+            // Notify the running BackgroundService so the scheduler starts/stops immediately
+            // rather than waiting for the next service restart.
+            startService(Intent(this, BackgroundService::class.java).apply {
+                action = BackgroundService.ACTION_SYNC_ENABLED_CHANGED
+            })
         }
 
         btnChooseDir.setOnClickListener {

--- a/mobile/src/main/res/layout/activity_sync_settings.xml
+++ b/mobile/src/main/res/layout/activity_sync_settings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="start">
+
+        <!-- Enable/disable sync toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Enable Sync"
+                android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_sync_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <!-- Sync directory status -->
+        <TextView
+            android:id="@+id/tv_sync_dir_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text="No sync directory configured." />
+
+        <!-- Choose directory button -->
+        <Button
+            android:id="@+id/btn_choose_sync_dir"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:text="Choose Directory"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+        <!-- Help text -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text="ActivityWatch can sync data between devices. Choose a directory accessible to your sync tool (e.g. Syncthing, Dropbox) — the Downloads folder is a common choice.\n\nSync is off by default. Enable it only after selecting a directory." />
+
+    </LinearLayout>
+</ScrollView>

--- a/mobile/src/main/res/menu/main.xml
+++ b/mobile/src/main/res/menu/main.xml
@@ -5,4 +5,8 @@
           android:title="@string/action_settings"
           android:orderInCategory="100"
           app:showAsAction="never"/>
+    <item android:id="@+id/action_sync_settings"
+          android:title="Sync Settings"
+          android:orderInCategory="101"
+          app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
## Summary

Follow-up to #203 (filed in ActivityWatch/activitywatch#1357) and the sync-disabled-by-default PR (#184). Adds the user-facing sync settings screen.

**What this adds:**
- `SyncSettingsActivity`: enable/disable toggle + `ACTION_OPEN_DOCUMENT_TREE` directory picker
- `AWPreferences`: `getSyncDirUri`/`setSyncDirUri` to persist the user-chosen SAF URI with persistable permissions across reboots
- "Sync Settings" menu item in MainActivity's options menu
- `activity_sync_settings.xml` layout

**How it works:**
1. User opens the overflow menu → "Sync Settings"
2. Toggle enables/disables sync (backed by existing `AWPreferences.isSyncEnabled()`)
3. "Choose Directory" launches `ACTION_OPEN_DOCUMENT_TREE` — the user picks any folder their sync tool (Syncthing, Dropbox, etc.) can see
4. The chosen URI is stored with `contentResolver.takePersistableUriPermission()` so it survives reboots
5. The screen shows the selected directory name on return

**Phase 1 scope:** This PR wires up the UI and preference plumbing. The native `aw-sync` library continues writing to the internal scoped directory via `AW_SYNC_DIR`. Phase 2 will bridge the internal sync dir to the SAF-granted location (file-copy or `DocumentFile`-based I/O rewrite) once the permissions infrastructure is confirmed working on real devices.

**APIs used:** All API 26+ (minSdkVersion 26 confirmed), including `DocumentsContract.EXTRA_INITIAL_URI` for suggesting a sensible starting location.

## Test plan
- [ ] Build and install debug APK
- [ ] Open overflow menu → verify "Sync Settings" appears
- [ ] Tap "Sync Settings" → verify screen opens with toggle and "Choose Directory" button
- [ ] Toggle enable/disable → confirm preference persists across app restarts
- [ ] Tap "Choose Directory" → verify system folder picker opens
- [ ] Select a folder → verify display name appears in status text
- [ ] Reinstall the app → verify SAF URI permission survives reboot (granted via `takePersistableUriPermission`)

Relates to ActivityWatch/activitywatch#1357 (@ErikBjare approved: "approved, go")