### PR TITLE
fix(notify): trim DEFAULT_ALERTS to 2-3 thresholds per category

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -33,10 +33,10 @@ internal data class CategoryAlert(
 )
 
 private val DEFAULT_ALERTS = listOf(
-    CategoryAlert(null,       "All",        listOf(60, 120, 240, 360, 480)),
-    CategoryAlert("Work",     "💼 Work",    listOf(15, 30, 60, 120, 240), positive = true),
-    CategoryAlert("Twitter",  "🐦 Twitter", listOf(15, 30, 60)),
-    CategoryAlert("YouTube",  "📺 YouTube", listOf(15, 30, 60)),
+    CategoryAlert(null,       "All",        listOf(60, 240, 480)),
+    CategoryAlert("Work",     "💼 Work",    listOf(60, 120, 240), positive = true),
+    CategoryAlert("Twitter",  "🐦 Twitter", listOf(15, 60)),
+    CategoryAlert("YouTube",  "📺 YouTube", listOf(30, 60)),
 )
 
 internal fun logicalDayDate(now: LocalDateTime, startOfDayHour: Int): LocalDate =


### PR DESCRIPTION
Follow-up to #202 (merged) — closes goal 3 from #201.

## What changed

`DEFAULT_ALERTS` reduced from 5 thresholds on `All`/`Work` down to 2–3 per category:

| Category | Before | After |
|---|---|---|
| All | 1h 2h 4h 6h 8h | 1h 4h 8h |
| Work (goal) | 15m 30m 1h 2h 4h | 1h 2h 4h |
| Twitter | 15m 30m 1h | 15m 1h |
| YouTube | 15m 30m 1h | 30m 1h |

The previous defaults were too dense for most days — a user doing 8h of tracked time would receive 5 notifications for `All` alone. The new set fires at meaningful checkpoints only.

These are still the *fallback* defaults: users who configure custom thresholds via `/api/0/settings/aw-notify` (shipped in #202) are unaffected.