### PR TITLE
docs(ci): cross-reference shared Android signing strategy with gptme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,13 @@ jobs:
         sed -i "s/versionCode .*/versionCode ${{needs.get-versionCode.outputs.versionCode}}/" \
                 mobile/build.gradle
 
+    # Signing strategy is shared with gptme/gptme (.github/workflows/tauri.yml
+    # release-android job + docs/contributing.rst "Android release signing"
+    # there); signing itself happens in scripts/sign_apk.sh via the Makefile.
+    # Keep the two implementations consistent when changing either.
+    # gptme delivers the keystore as a base64 secret instead of age-encrypted
+    # in-repo, pins the signer cert SHA-256, and fails closed on missing
+    # secrets — planned to be adopted here too (see issue tracker).
     - uses: adnsio/setup-age-action@v1.2.0
     - name: Load Android secrets
       if: env.KEY_ANDROID_JKS != null

--- a/scripts/sign_apk.sh
+++ b/scripts/sign_apk.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 # Signs APKs or AABs using the android.jks keystore
+#
+# This signing strategy (zipalign, then apksigner for APKs and jarsigner for
+# AABs, passwords via env vars) is intentionally shared with gptme's Android
+# release signing (gptme/gptme .github/workflows/tauri.yml release-android job,
+# documented in docs/contributing.rst "Android release signing" there).
+# Keep the two implementations consistent when changing either.
+# gptme additionally pins the signer cert SHA-256 and fails closed when
+# signing secrets are missing — planned to be adopted here too.
 
 set -e
 


### PR DESCRIPTION
gptme now signs its Android releases (gptme/gptme#3409) using the same battle-tested flow as this repo: zipalign before signing, apksigner for APKs, jarsigner for AABs, passwords via env vars.

This adds comments in `scripts/sign_apk.sh` and `.github/workflows/build.yml` pointing at the sibling implementation, so future changes to either keep the two consistent.

gptme's implementation additionally:
- delivers the keystore as a base64 environment secret (instead of age-encrypted in-repo)
- pins the expected signer certificate SHA-256 and verifies it before upload
- fails closed when signing secrets are missing (instead of shipping unsigned)

Plan is to adopt those improvements here too — tracked in a follow-up issue.