### PR TITLE
fix: replace Material attrs with AppCompat in settings activities

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt
@@ -14,8 +14,8 @@ import android.widget.CompoundButton
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -29,7 +29,7 @@ class AuthSettingsActivity : AppCompatActivity() {
     private lateinit var tvStatus: TextView
     private lateinit var btnCopy: Button
     private lateinit var btnRegenerate: Button
-    private lateinit var switchAuthEnabled: SwitchMaterial
+    private lateinit var switchAuthEnabled: SwitchCompat
 
     // Guards against the switch listener firing when we set isChecked programmatically
     private var isUpdatingSwitch = false

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -178,6 +178,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                 fragmentClass = WebUIFragment::class.java
                 url = authenticatedUrl("$baseURL/#/settings/")
             }
+            R.id.nav_auth_settings -> {
+                startActivity(Intent(this, AuthSettingsActivity::class.java))
+            }
             R.id.nav_share -> {
                 openDashboardInBrowser()
             }

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -13,7 +13,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.switchmaterial.SwitchMaterial
+import androidx.appcompat.widget.SwitchCompat
 
 private const val TAG = "SyncSettingsActivity"
 
@@ -21,7 +21,7 @@ class SyncSettingsActivity : AppCompatActivity() {
 
     private lateinit var prefs: AWPreferences
 
-    private lateinit var switchSyncEnabled: SwitchMaterial
+    private lateinit var switchSyncEnabled: SwitchCompat
     private lateinit var tvSyncDirStatus: TextView
     private lateinit var btnChooseDir: Button
 

--- a/mobile/src/main/res/layout/activity_auth_settings.xml
+++ b/mobile/src/main/res/layout/activity_auth_settings.xml
@@ -23,9 +23,9 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="Require API Authentication"
-                android:textAppearance="?attr/textAppearanceBodyLarge" />
+                android:textAppearance="?android:attr/textAppearanceListItem" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/switch_auth_enabled"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
@@ -38,8 +38,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
             android:text="Checking…" />
 
         <!-- API key section -->
@@ -48,7 +48,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
             android:text="Current API Key"
-            android:textAppearance="?attr/textAppearanceLabelLarge" />
+            android:textAppearance="?android:attr/textAppearanceListItemSmall" />
 
         <TextView
             android:id="@+id/tv_api_key"
@@ -59,7 +59,7 @@
             android:fontFamily="monospace"
             android:paddingHorizontal="12dp"
             android:paddingVertical="10dp"
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textAppearance="?android:attr/textAppearanceMedium"
             android:textIsSelectable="true"
             android:text="(none)" />
 
@@ -76,7 +76,7 @@
                 android:layout_weight="1"
                 android:layout_marginEnd="8dp"
                 android:text="Copy Key"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+                style="@style/Widget.AppCompat.Button.Borderless" />
 
             <Button
                 android:id="@+id/btn_regenerate_key"
@@ -84,7 +84,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="Regenerate Key"
-                style="@style/Widget.MaterialComponents.Button" />
+                style="@style/Widget.AppCompat.Button" />
 
         </LinearLayout>
 
@@ -92,8 +92,8 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
             android:text="When enabled, ActivityWatch clients (browser, desktop app) must include this key to access data. Use the key in the URL:\n\nhttp://localhost:5600/?token=YOUR_KEY\n\nChanges take effect after restarting the app." />
 
     </LinearLayout>

--- a/mobile/src/main/res/layout/activity_sync_settings.xml
+++ b/mobile/src/main/res/layout/activity_sync_settings.xml
@@ -23,9 +23,9 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="Enable Sync"
-                android:textAppearance="?attr/textAppearanceBodyLarge" />
+                android:textAppearance="?android:attr/textAppearanceListItem" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/switch_sync_enabled"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
@@ -38,8 +38,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
             android:text="No sync directory configured." />
 
         <!-- Choose directory button -->
@@ -49,14 +49,14 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
             android:text="Choose Directory"
-            style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+            style="@style/Widget.AppCompat.Button.Borderless" />
 
         <!-- Help text -->
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
             android:text="ActivityWatch can sync data between devices. Choose a directory accessible to your sync tool (e.g. Syncthing, Dropbox) — the Downloads folder is a common choice.\n\nSync is off by default. Enable it only after selecting a directory." />
 
     </LinearLayout>

--- a/mobile/src/main/res/menu/activity_main_drawer.xml
+++ b/mobile/src/main/res/menu/activity_main_drawer.xml
@@ -24,11 +24,11 @@
                 <item
                         android:id="@+id/nav_settings"
                         android:icon="@drawable/ic_menu_manage"
-                        android:title="Dashboard Settings"/>
+                        android:title="@string/dashboard_settings"/>
                 <item
                         android:id="@+id/nav_auth_settings"
                         android:icon="@drawable/ic_menu_manage"
-                        android:title="API Authentication"/>
+                        android:title="@string/api_authentication"/>
                 <item
                         android:id="@+id/nav_share"
                         android:icon="@drawable/ic_menu_share"

--- a/mobile/src/main/res/menu/activity_main_drawer.xml
+++ b/mobile/src/main/res/menu/activity_main_drawer.xml
@@ -24,7 +24,11 @@
                 <item
                         android:id="@+id/nav_settings"
                         android:icon="@drawable/ic_menu_manage"
-                        android:title="Settings"/>
+                        android:title="Dashboard Settings"/>
+                <item
+                        android:id="@+id/nav_auth_settings"
+                        android:icon="@drawable/ic_menu_manage"
+                        android:title="API Authentication"/>
                 <item
                         android:id="@+id/nav_share"
                         android:icon="@drawable/ic_menu_share"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="nav_header_subtitle">v0.1.0</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
+    <string name="dashboard_settings">Dashboard Settings</string>
+    <string name="api_authentication">API Authentication</string>
     <string name="open_in_browser">Open in browser</string>
     <string name="title_activity_buckets">BucketsActivity</string>
     <string name="welcome_title_text">Welcome, early user!</string>


### PR DESCRIPTION
Fixes #210

## Root cause

`AuthSettingsActivity` and `SyncSettingsActivity` use Material Components 3 attrs in their layouts (`textAppearanceBodySmall`, `colorOnSurfaceVariant`, `SwitchMaterial`, `Widget.MaterialComponents.Button.*`) under the app's `AppTheme` which inherits `Theme.AppCompat.Light.NoActionBar`. The AppCompat parent theme does not define the M3 token system, causing `InflateException` on activity launch.

## Fix

Replace all M3 attrs with their AppCompat/platform equivalents in both layout files and the corresponding Kotlin files:

| M3 | AppCompat replacement |
|----|----------------------|
| `?attr/textAppearanceBodyLarge` | `?android:attr/textAppearanceListItem` |
| `?attr/textAppearanceBodySmall` | `?android:attr/textAppearanceSmall` |
| `?attr/colorOnSurfaceVariant` | `?android:attr/textColorSecondary` |
| `?attr/textAppearanceLabelLarge` | `?android:attr/textAppearanceListItemSmall` |
| `?attr/textAppearanceBodyMedium` | `?android:attr/textAppearanceMedium` |
| `SwitchMaterial` | `SwitchCompat` (layout + Kotlin) |
| `Widget.MaterialComponents.Button.*` | `Widget.AppCompat.Button.*` |

Also adds "API Authentication" to the nav drawer in `activity_main_drawer.xml` and `MainActivity.kt` — on gesture-nav devices the options menu overflow is unreachable, so users couldn't discover the auth settings screen.

## Changes

- `mobile/src/main/res/layout/activity_auth_settings.xml` — M3 → AppCompat attrs
- `mobile/src/main/java/net/activitywatch/android/AuthSettingsActivity.kt` — `SwitchMaterial` → `SwitchCompat`
- `mobile/src/main/res/layout/activity_sync_settings.xml` — same M3 → AppCompat attrs
- `mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt` — `SwitchMaterial` → `SwitchCompat`
- `mobile/src/main/res/menu/activity_main_drawer.xml` — add "API Authentication" item
- `mobile/src/main/java/net/activitywatch/android/MainActivity.kt` — handle `nav_auth_settings`