### PR TITLE
build: bump compileSdk/targetSdk to 36 (Android 16)

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 35
+    compileSdk 36
     ndkVersion "25.2.9519653"
 
     defaultConfig {
         applicationId "net.activitywatch.android"
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
 
         // Keep versionName committed in source so tagged builds and F-Droid agree.
         // Tag workflows verify it matches refs/tags/v* instead of rewriting the checkout.


### PR DESCRIPTION
Part of Play Store policy compliance: *App must target Android 16 (API level 36) or higher — Fix by Aug 31* (Play Console warning, ~3 weeks away).

The app already targets API 35, so the significant behavior changes from that generation (edge-to-edge enforcement etc.) are already absorbed. Targeting 36 mainly picks up stricter intent matching and predictive-back defaults, neither of which this app relies on.

CI's emulator E2E (API 29) plus unit tests cover the regression risk; a manual smoke test on an Android 16 device before the next Play release is still advisable.

Sibling PRs for the other Play policy items: #213 (16 KB pages); accessibility prominent disclosure to follow.