### PR TITLE
fix: add prominent disclosure before accessibility settings redirect

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -144,9 +145,18 @@ class PermissionsFragment : Fragment() {
         view.findViewById<Button>(R.id.btnGrantUsagePermission).setOnClickListener {
             startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS))
         }
-        // Handle grant accessibility permissions
+        // Handle grant accessibility permissions.
+        // Google Play's Accessibility API policy requires a prominent disclosure
+        // that the user affirmatively accepts before being sent to enable the service.
         view.findViewById<Button>(R.id.btnGrantAccessibilityPermission).setOnClickListener {
-            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+            AlertDialog.Builder(requireContext())
+                .setTitle(R.string.accessibility_disclosure_title)
+                .setMessage(R.string.accessibility_disclosure_message)
+                .setPositiveButton(R.string.accessibility_disclosure_agree) { _, _ ->
+                    startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+                }
+                .setNegativeButton(R.string.accessibility_disclosure_decline, null)
+                .show()
         }
         // Handle grant exact alarm permissions (for widgets)
         view.findViewById<Button>(R.id.btnGrantExactAlarmPermission).setOnClickListener {

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -24,6 +24,14 @@
     <string name="button_log_text">Click me to log data!</string>
     <string name="accessibility_service_description">Allows ActivityWatch to read the URL and title from your browser.</string>
 
+    <!-- Prominent disclosure required by the Google Play Accessibility API policy:
+         must be shown and affirmatively accepted BEFORE directing the user to
+         enable the accessibility service. -->
+    <string name="accessibility_disclosure_title">Web browsing tracking</string>
+    <string name="accessibility_disclosure_message">To track your web browsing activity, ActivityWatch uses Android\'s Accessibility API to read the URL and page title from your browser while you browse.\n\nThis data is processed and stored only on your device. It is never sent to the ActivityWatch developers or any third party.\n\nIf you agree, enable ActivityWatch under Accessibility settings on the next screen. This is optional — the rest of the app works without it.</string>
+    <string name="accessibility_disclosure_agree">Agree</string>
+    <string name="accessibility_disclosure_decline">No thanks</string>
+
     <!-- This is overridden by gradle config
     <string name="versionName">unknown version</string>-->
 


### PR DESCRIPTION
Part of Play Store policy compliance: *Accessibility API Policy: Missing prominent disclosure* — the standing rejection from Oct 2023.

## Problem

The onboarding "grant accessibility" button jumped straight to `ACTION_ACCESSIBILITY_SETTINGS`. Google's [Accessibility API policy](https://support.google.com/googleplay/android-developer/answer/10964491) requires an in-app **prominent disclosure** that the user affirmatively accepts *before* being directed to enable the service, stating what data is accessed and how it's used.

## Fix

An `AlertDialog` on the button now states: what is collected (browser URL + page title via the Accessibility API), why (web browsing tracking), that data is stored only on-device and never sent to developers/third parties, and that the feature is optional. "Agree" proceeds to the settings screen; "No thanks" dismisses.

## Remaining manual step (Play Console)

Code alone doesn't clear this flag — the **AccessibilityService declaration form** in Play Console (App content → Sensitive app permissions / Accessibility) must also be filled in, declaring the service is not primarily for accessibility and describing the core functionality. Worth doing in the same pass as the resubmission.

Sibling PRs: #213 (16 KB pages), #214 (target API 36).