### PR TITLE
fix(release): cap Play Store changelog at 500 characters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,6 @@ jobs:
           CHANGELOG="fastlane/metadata/android/en-US/changelogs/${VERSION_CODE}.txt"
           if [ -f "$CHANGELOG" ]; then
             echo "Using existing changelog: $CHANGELOG"
-            cat "$CHANGELOG"
           else
             # Auto-generate from git log since the previous tag, skipping chore commits
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
@@ -120,9 +119,38 @@ jobs:
             if [ ! -s "$CHANGELOG" ]; then
               echo "- Bug fixes and stability improvements" > "$CHANGELOG"
             fi
-            echo "Generated $CHANGELOG:"
-            cat "$CHANGELOG"
+            echo "Generated $CHANGELOG"
           fi
+
+          # Google Play rejects release notes longer than 500 characters per
+          # language, and fastlane only surfaces this at upload time — after the
+          # tag has already been pushed. Trim here, on whole-line boundaries, so
+          # a release is never blocked by a long changelog.
+          # Byte length is used as the bound: for UTF-8 it is >= the character
+          # count Google measures, so this can only ever be conservative.
+          # When entries are dropped, point at the GitHub release for the full
+          # list. Play Store "What's new" is plain text — the URL is readable
+          # but not clickable — so keep it short and recognisable.
+          MAX_BYTES=500
+          MORE_LINE="Full changelog: https://github.com/ActivityWatch/aw-android/releases/tag/v${{ inputs.version }}"
+          if [ "$(wc -c < "$CHANGELOG")" -gt "$MAX_BYTES" ]; then
+            echo "::warning::$CHANGELOG is $(wc -c < "$CHANGELOG") bytes; trimming to Google Play's ${MAX_BYTES}-character limit"
+            BUDGET=$(( MAX_BYTES - ${#MORE_LINE} - 2 ))
+            awk -v budget="$BUDGET" '
+              { need = length($0) + 1 }
+              used + need > budget { exit }
+              { print; used += need }
+            ' "$CHANGELOG" > "${CHANGELOG}.tmp"
+            if [ ! -s "${CHANGELOG}.tmp" ]; then
+              # Not even the first entry fits — fall back to a generic note.
+              printf '%s\n' "- Bug fixes and stability improvements" > "${CHANGELOG}.tmp"
+            fi
+            printf '\n%s\n' "$MORE_LINE" >> "${CHANGELOG}.tmp"
+            mv "${CHANGELOG}.tmp" "$CHANGELOG"
+          fi
+
+          echo "Final changelog ($(wc -c < "$CHANGELOG") bytes):"
+          cat "$CHANGELOG"
 
       - name: Commit and tag
         run: |

--- a/fastlane/metadata/android/en-US/changelogs/38.txt
+++ b/fastlane/metadata/android/en-US/changelogs/38.txt
@@ -3,11 +3,5 @@
 - build: bump compileSdk/targetSdk to 36 (Android 16) (#214)
 - feat(sync): bridge SAF-granted URI to aw-sync output (Phase 2) (#209)
 - fix: replace Material attrs with AppCompat in settings activities (#211)
-- docs(ci): cross-reference shared Android signing strategy with gptme (#207)
-- feat(sync): add SyncSettingsActivity — enable/disable toggle + SAF directory picker (#204)
-- fix(widget): match Activity view startOfDay and add open-app button (#198)
-- fix(notify): trim DEFAULT_ALERTS to 2-3 thresholds per category (#206)
-- feat(notify): read alert config from server settings, fall back to defaults (#202)
-- feat(notify): add aw-notify support — activity-time threshold alerts (#199)
-- feat: add POST_NOTIFICATIONS permission and runtime request (#195)
-- fix(fastlane): add changelog 36.txt and auto-generate changelogs in CI (#194)
+
+Full changelog: https://github.com/ActivityWatch/aw-android/releases/tag/v0.14.0


### PR DESCRIPTION
## Problem

Build run [31387869696](https://github.com/ActivityWatch/aw-android/actions/runs/31387869696/job/93456444592) failed at the Play Store upload step:

```
[!] Google Api Error: Invalid request - The release created has notes in language
    en-US with length 1004, which is too long (max: 500).
```

Google Play caps release notes at **500 characters per language**. The changelog auto-generation added in #194 emits an unbounded `git log` since the previous tag, so it exceeds the cap whenever a release spans more than a handful of commits. `v0.14.0dev20260810` spanned 13 → 1004 characters.

The failure mode is worse than a plain build break: `release.yml` commits the changelog and pushes the tag *before* `build.yml` uploads, so the error surfaces after the release has effectively been cut.

## Fix

Trim in `release.yml`, on whole-line boundaries, so a half-written entry never ships. When entries are dropped, append a pointer to the GitHub release:

```
- fix: add prominent disclosure before accessibility settings redirect (#215)
- build: bump NDK to r28 for 16 KB page-size compliance (conflict resolution) (#217)
- build: bump compileSdk/targetSdk to 36 (Android 16) (#214)
- feat(sync): bridge SAF-granted URI to aw-sync output (Phase 2) (#209)
- fix: replace Material attrs with AppCompat in settings activities (#211)

Full changelog: https://github.com/ActivityWatch/aw-android/releases/tag/v0.14.0
```

453 bytes. Note that Play Store "What's new" is plain text — the URL is readable but not clickable. Still better than dropping the remainder silently.

Details:

- The bound is measured in **bytes**. For UTF-8 that is >= the character count Google measures, so the check can only ever be conservative, never over-permissive.
- The cap runs **after both branches**, so a hand-written changelog that is too long is also caught — that path was previously unchecked and would have failed identically.
- If not even the first entry fits, it falls back to `- Bug fixes and stability improvements` rather than emitting an empty file.
- The link is only added when truncation actually happened; short changelogs are left clean. Say the word if you'd rather it were always present.

## Also in this PR

`fastlane/metadata/android/en-US/changelogs/38.txt` is committed on master at 1008 bytes. Trimmed to 453 — without this, any re-run of the `v0.14.0dev20260810` build fails the same way.

## Verification

Ran the capping logic against the real 1008-byte changelog and the edge cases:

| Input | Result |
|---|---|
| The actual 1008-byte 38.txt | 453 bytes, 5 whole entries + release link |
| Short changelog (12 bytes) | unchanged, no link appended |
| Single entry longer than the budget | falls back to the generic note + link |
| 499 bytes (just under) | unchanged |
| Empty | unchanged (the existing `! -s` guard fills it first) |

`shellcheck -s bash` clean on the extracted step; `release.yml` parses as valid YAML.

## Context

This is the last thing between master and a stable v0.14.0 — the foreground-service declaration cleared review, and this run got all the way to the upload step. Tracked in #189.