### PR TITLE
fix(sync): make Sync Settings reachable from the navigation drawer

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -181,6 +181,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             R.id.nav_auth_settings -> {
                 startActivity(Intent(this, AuthSettingsActivity::class.java))
             }
+            R.id.nav_sync_settings -> {
+                startActivity(Intent(this, SyncSettingsActivity::class.java))
+            }
             R.id.nav_share -> {
                 openDashboardInBrowser()
             }

--- a/mobile/src/main/res/menu/activity_main_drawer.xml
+++ b/mobile/src/main/res/menu/activity_main_drawer.xml
@@ -30,6 +30,10 @@
                         android:icon="@drawable/ic_menu_manage"
                         android:title="@string/api_authentication"/>
                 <item
+                        android:id="@+id/nav_sync_settings"
+                        android:icon="@drawable/ic_menu_manage"
+                        android:title="@string/sync_settings"/>
+                <item
                         android:id="@+id/nav_share"
                         android:icon="@drawable/ic_menu_share"
                         android:title="@string/open_in_browser"/>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="action_settings">Settings</string>
     <string name="dashboard_settings">Dashboard Settings</string>
     <string name="api_authentication">API Authentication</string>
+    <string name="sync_settings">Sync Settings</string>
     <string name="open_in_browser">Open in browser</string>
     <string name="title_activity_buckets">BucketsActivity</string>
     <string name="welcome_title_text">Welcome, early user!</string>


### PR DESCRIPTION
## Problem

`SyncSettingsActivity` (added in #204) cannot be opened on a real device.

It is registered only in `res/menu/main.xml`, the options menu — but that menu is never rendered:

- `MainActivity` uses `AppTheme.NoActionBar`
- it never calls `setSupportActionBar(...)`
- the `Toolbar` in `res/layout/app_bar_main.xml` has been commented out since `4a02a0b` (2018-12-16)

So `onCreateOptionsMenu()` inflates a menu with no host, and no overflow (⋮) button appears anywhere. `res/menu/activity_main_drawer.xml` has no sync entry either, so there is no route to the screen at all.

It cannot be reached from outside the app either: the activity is `android:exported="false"`, and `adb shell am start -n ...` is refused on OEM builds that do not grant `START_ANY_ACTIVITY` to the shell uid (confirmed on a OnePlus/ColorOS device: `SecurityException ... not exported from uid`).

The same is true of `action_settings` → `AuthSettingsActivity`, which is why that one is *also* present in the drawer as `nav_auth_settings`. Sync never got the equivalent.

## Change

Adds `nav_sync_settings` to the drawer, mirroring exactly how `nav_auth_settings` exposes the sibling activity: one `<item>`, one string resource, one branch in `onNavigationItemSelected`.

## Testing

Built and installed on a physical device (Android 16, arm64). The entry appears under **Misc**, below *API Authentication*, and opens the sync settings screen.

Worth noting for anyone reproducing: because there is no ActionBar there is also no hamburger button, so the drawer only opens by **swiping in from the left edge**.

## Alternative

Restoring the commented-out `Toolbar` and calling `setSupportActionBar()` would fix the options menu generally and bring back the hamburger affordance. That is a larger UI change with more room for regression, so this PR takes the smaller route that matches the existing pattern. Happy to do it that way instead if preferred.