### PR TITLE
fix(widget): group category time by full path, matching the Activity view

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
+++ b/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
@@ -298,9 +298,15 @@ object CategoryTimeWidgetUpdater {
         }
 
         /**
-         * Parse category events from the androidQuery response
+         * Parse category events from the androidQuery response.
+         *
+         * Groups by the full category path, matching the Activity view: aw-webui builds
+         * cat_events with `merge_events_by_keys(events, ["$category"])` and labels them
+         * with `$category.join(" > ")`. Rolling up to the top-level category here would
+         * make per-category times disagree with the Activity view even though the totals
+         * match (ActivityWatch/aw-android#142).
          */
-        private fun parseCategories(jsonResult: String): List<Pair<String, Long>> {
+        internal fun parseCategories(jsonResult: String): List<Pair<String, Long>> {
             val categories = mutableMapOf<String, Double>()
 
             try {
@@ -319,11 +325,11 @@ object CategoryTimeWidgetUpdater {
                     val categoryArray = data.optJSONArray("\$category")
                     if (categoryArray == null || categoryArray.length() == 0) continue
 
-                    // Get top-level category (first element only)
-                    val topLevelCategory = categoryArray.optString(0, "Uncategorized")
-                    
-                    // Aggregate time by top-level category
-                    categories[topLevelCategory] = categories.getOrDefault(topLevelCategory, 0.0) + duration
+                    // Full category path, e.g. ["Work", "Programming"] -> "Work > Programming"
+                    val categoryPath = (0 until categoryArray.length())
+                        .joinToString(" > ") { categoryArray.optString(it, "Uncategorized") }
+
+                    categories[categoryPath] = categories.getOrDefault(categoryPath, 0.0) + duration
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error parsing categories", e)

--- a/mobile/src/test/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdaterTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdaterTest.kt
@@ -1,0 +1,91 @@
+package net.activitywatch.android.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CategoryTimeWidgetUpdaterTest {
+
+    private fun catEvent(duration: Double, vararg category: String): String {
+        val cats = category.joinToString(",") { "\"$it\"" }
+        return """{"duration":$duration,"data":{"${'$'}category":[$cats]}}"""
+    }
+
+    private fun response(vararg events: String) =
+        """[{"cat_events":[${events.joinToString(",")}]}]"""
+
+    /**
+     * Regression for ActivityWatch/aw-android#142: the widget rolled every event up to its
+     * top-level category, so subcategories collapsed together and per-category times
+     * disagreed with the Activity view (which groups by the full `$category` path) even
+     * though the totals matched.
+     */
+    @Test
+    fun parseCategories_keepsSubcategoriesSeparate() {
+        val result = CategoryTimeWidgetUpdater.parseCategories(
+            response(
+                catEvent(60.0, "Work", "Programming"),
+                catEvent(30.0, "Work", "Planning")
+            )
+        )
+
+        assertEquals(
+            listOf("Work > Programming" to 60_000L, "Work > Planning" to 30_000L),
+            result
+        )
+    }
+
+    @Test
+    fun parseCategories_totalIsUnchangedBySubcategorySplit() {
+        val result = CategoryTimeWidgetUpdater.parseCategories(
+            response(
+                catEvent(60.0, "Work", "Programming"),
+                catEvent(30.0, "Work", "Planning"),
+                catEvent(10.0, "Media")
+            )
+        )
+
+        assertEquals(100_000L, result.sumOf { it.second })
+    }
+
+    @Test
+    fun parseCategories_mergesRepeatsOfTheSamePath() {
+        val result = CategoryTimeWidgetUpdater.parseCategories(
+            response(
+                catEvent(60.0, "Work", "Programming"),
+                catEvent(15.0, "Work", "Programming")
+            )
+        )
+
+        assertEquals(listOf("Work > Programming" to 75_000L), result)
+    }
+
+    @Test
+    fun parseCategories_sortsByDurationDescending() {
+        val result = CategoryTimeWidgetUpdater.parseCategories(
+            response(
+                catEvent(10.0, "Media", "Video"),
+                catEvent(90.0, "Work", "Programming"),
+                catEvent(50.0, "Comms")
+            )
+        )
+
+        assertEquals(
+            listOf("Work > Programming", "Comms", "Media > Video"),
+            result.map { it.first }
+        )
+    }
+
+    @Test
+    fun parseCategories_keepsSingleLevelCategoriesUnprefixed() {
+        val result = CategoryTimeWidgetUpdater.parseCategories(
+            response(catEvent(20.0, "Uncategorized"))
+        )
+
+        assertEquals(listOf("Uncategorized" to 20_000L), result)
+    }
+
+    @Test
+    fun parseCategories_returnsEmptyForEmptyResult() {
+        assertEquals(emptyList<Pair<String, Long>>(), CategoryTimeWidgetUpdater.parseCategories("[]"))
+    }
+}


### PR DESCRIPTION
Fixes the per-category discrepancy @ErikBjare reported in #142 ("category time presented seems to diff from Activity view (total time matches though)").

## Cause

`parseCategories()` aggregated by `$category[0]` — the top-level category only. So `["Work","Programming"]` and `["Work","Planning"]` both landed in one `Work` bucket. The total was unaffected (same events, same durations), which is exactly why totals matched while per-category rows did not.

The Activity view groups by the **full** category path: aw-webui builds `cat_events` with `merge_events_by_keys(events, ["$category"])` and renders them with `namefunc="e => e.data['$category'].join(' > ')"` (`SelectableVisualization.vue`, `top_categories`).

## Fix

Group by the full category path and label it the same way (`"Work > Programming"`).

## Tests

Adds `CategoryTimeWidgetUpdaterTest` (6 cases). Three of them fail against the old top-level rollup and pass with the fix:

- `parseCategories_keepsSubcategoriesSeparate`
- `parseCategories_mergesRepeatsOfTheSamePath`
- `parseCategories_sortsByDurationDescending`

Verified locally with `./gradlew :mobile:testDebugUnitTest --tests 'net.activitywatch.android.widget.*'`.

## Not in this PR

- `NotifyWorker.parseCategorySeconds()` has the same top-level rollup, but its keys are matched against configured alert categories, so changing it would alter alert behaviour. Worth a separate look.
- @0xbrayo's widget preview request — separate change.