### PR TITLE
fix(notify): restore notification text from PR #223 while keeping icon fix from PR #227

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
+++ b/mobile/src/main/java/net/activitywatch/android/BackgroundService.kt
@@ -213,8 +213,8 @@ class BackgroundService : Service() {
             }
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("ActivityWatch Server")
-            .setContentText("Server and sync running in background")
+            .setContentTitle("ActivityWatch")
+            .setContentText("Running in the background")
             // Adaptive launcher mipmaps are not valid status-bar icons (alpha-only).
             .setSmallIcon(R.drawable.ic_stat_notification)
             .setContentIntent(pendingIntent)


### PR DESCRIPTION
## Problem

PR #227 accidentally reverted user-friendly text changes from PR #223 while adding the notification icon fix.

Notification text was changed from the clean version:
- 'ActivityWatch' → 'ActivityWatch Server' ❌
- 'Running in the background' → 'Server and sync running in background' ❌

But the icon fix (using ic_stat_notification) should be preserved.

## Solution

Restore the notification text improvements from PR #223 while keeping the icon fix from PR #227.

The final notification now has:
- Clean, user-friendly title: 'ActivityWatch' ✓
- Clear description: 'Running in the background' ✓
- Proper notification icon: ic_stat_notification ✓

## Related
Fixes #226