### PR TITLE
fix(android): load background settings from datastore

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -50,6 +50,7 @@ class RustInterface(context: Context? = null) {
     external fun heartbeat(bucket_id: String, event: String, pulsetime: Double): String
     external fun query(query: String, timeperiods: String): String
     external fun androidQuery(timeperiods: String): String
+    external fun getSetting(key: String): String
     external fun migrateHostname(hostname: String): String
 
     fun sayHello(to: String): String {

--- a/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
+++ b/mobile/src/main/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdater.kt
@@ -26,7 +26,6 @@ import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 
 private const val TAG = "CategoryTimeWidget"
-private val DEFAULT_START_OF_DAY = LocalTime.of(4, 0)  // matches aw-webui default "04:00"
 
 // Bar chart dimensions
 private const val BAR_WIDTH = 400
@@ -44,6 +43,8 @@ private val CATEGORY_ACCENT_COLORS = intArrayOf(
  * Utility object that updates the widget data.
  */
 object CategoryTimeWidgetUpdater {
+
+    private val DEFAULT_START_OF_DAY = LocalTime.of(4, 0)  // matches aw-webui default "04:00"
 
     // App row IDs
     private val appRowIds = intArrayOf(
@@ -231,30 +232,8 @@ object CategoryTimeWidgetUpdater {
         }
 
         /**
-         * Fetch the startOfDay boundary from the AW server settings API.
-         * Falls back to DEFAULT_START_OF_DAY if the server is unavailable or the setting is unset.
-         */
-        private fun fetchStartOfDay(): LocalTime {
-            return try {
-                val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/startOfDay")
-                val conn = url.openConnection() as java.net.HttpURLConnection
-                conn.connectTimeout = 1000
-                conn.readTimeout = 1000
-                if (conn.responseCode == 200) {
-                    parseStartOfDay(conn.inputStream.bufferedReader().readText())
-                } else {
-                    Log.d(TAG, "startOfDay setting unavailable (HTTP ${conn.responseCode}), using default")
-                    DEFAULT_START_OF_DAY
-                }
-            } catch (e: Exception) {
-                Log.d(TAG, "Could not fetch startOfDay setting, using default: ${e.message}")
-                DEFAULT_START_OF_DAY
-            }
-        }
-
-        /**
-         * Parse the server's startOfDay JSON response into a LocalTime.
-         * Server returns null (unset) or a quoted string like "04:00" or "04:30".
+         * Parse the datastore's startOfDay JSON value into a LocalTime.
+         * Native settings return null (unset) or a quoted string like "04:00" or "04:30".
          */
         internal fun parseStartOfDay(response: String): LocalTime {
             val v = response.trim()
@@ -264,7 +243,11 @@ object CategoryTimeWidgetUpdater {
                     val parts = v.trim('"').split(":")
                     val hour = parts.getOrNull(0)?.toIntOrNull() ?: return DEFAULT_START_OF_DAY
                     val minute = parts.getOrNull(1)?.toIntOrNull() ?: 0
-                    LocalTime.of(hour, minute)
+                    try {
+                        LocalTime.of(hour, minute)
+                    } catch (e: Exception) {
+                        DEFAULT_START_OF_DAY
+                    }
                 }
                 else -> DEFAULT_START_OF_DAY
             }
@@ -272,12 +255,13 @@ object CategoryTimeWidgetUpdater {
 
         /**
          * Query today's category times, using the same day boundary as aw-webui.
-         * Reads startOfDay from the AW server settings so the widget matches the Activity view.
+         * Reads startOfDay directly from the datastore so the widget matches the Activity view
+         * even when the authenticated HTTP server is unavailable.
          */
         private fun getCategoryTimesToday(ri: RustInterface): List<Pair<String, Long>> {
             val zone = ZoneId.systemDefault()
             val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-            val startOfDayTime = fetchStartOfDay()
+            val startOfDayTime = parseStartOfDay(ri.getSetting("startOfDay"))
 
             // Match aw-webui's day boundary: if current time is before startOfDay we're still
             // in the previous day's period (e.g. 3:45 AM with startOfDay=04:00 → "yesterday")

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -64,6 +64,27 @@ internal fun parseAlerts(json: String): List<CategoryAlert> {
     }
 }
 
+internal fun alertsFromSetting(json: String): List<CategoryAlert> {
+    val value = json.trim()
+    if (value.isEmpty() || value == "null") return DEFAULT_ALERTS
+
+    return try {
+        parseAlerts(value).takeIf { it.isNotEmpty() } ?: DEFAULT_ALERTS
+    } catch (e: Exception) {
+        DEFAULT_ALERTS
+    }
+}
+
+internal fun parseStartOfDayHour(response: String): Int {
+    val value = response.trim()
+    val hour = when {
+        value == "null" -> null
+        value.startsWith("\"") -> value.trim('"').split(":").firstOrNull()?.toIntOrNull()
+        else -> value.toIntOrNull()
+    }
+    return hour?.takeIf { it in 0..23 } ?: DEFAULT_START_OF_DAY_HOUR
+}
+
 // Include thresholds in the pref key so state resets when configuration changes.
 // A lowered threshold mid-day would otherwise be silently skipped because the old
 // triggered value is higher than all new thresholds.
@@ -89,10 +110,10 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
 
         return try {
             val zone = ZoneId.systemDefault()
-            val startOfDayHour = fetchStartOfDayHour()
+            val startOfDayHour = parseStartOfDayHour(ri.getSetting("startOfDay"))
             val now = LocalDateTime.now(zone)
             val categorySeconds = getCategorySecondsToday(ri, now, zone, startOfDayHour)
-            val alerts = fetchAlerts()
+            val alerts = alertsFromSetting(ri.getSetting("aw-notify"))
             checkAndNotify(categorySeconds, logicalDayDate(now, startOfDayHour), alerts)
             Result.success()
         } catch (e: Exception) {
@@ -225,51 +246,6 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
             }
             (applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
                 .createNotificationChannel(channel)
-        }
-    }
-
-    private fun fetchStartOfDayHour(): Int {
-        return try {
-            val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/startOfDay")
-            val conn = url.openConnection() as java.net.HttpURLConnection
-            conn.connectTimeout = 1_000
-            conn.readTimeout = 1_000
-            if (conn.responseCode == 200) {
-                parseStartOfDayHour(conn.inputStream.bufferedReader().readText())
-            } else {
-                DEFAULT_START_OF_DAY_HOUR
-            }
-        } catch (e: Exception) {
-            DEFAULT_START_OF_DAY_HOUR
-        }
-    }
-
-    private fun fetchAlerts(): List<CategoryAlert> {
-        return try {
-            val url = java.net.URL("http://127.0.0.1:5600/api/0/settings/aw-notify")
-            val conn = url.openConnection() as java.net.HttpURLConnection
-            conn.connectTimeout = 1_000
-            conn.readTimeout = 1_000
-            if (conn.responseCode == 200) {
-                val text = conn.inputStream.bufferedReader().readText().trim()
-                if (text == "null" || text.isBlank()) DEFAULT_ALERTS
-                else parseAlerts(text).takeIf { it.isNotEmpty() } ?: DEFAULT_ALERTS
-            } else {
-                DEFAULT_ALERTS
-            }
-        } catch (e: Exception) {
-            Log.d(TAG, "Could not fetch alert config from server, using defaults")
-            DEFAULT_ALERTS
-        }
-    }
-
-    private fun parseStartOfDayHour(response: String): Int {
-        val v = response.trim()
-        return when {
-            v == "null" -> DEFAULT_START_OF_DAY_HOUR
-            v.startsWith("\"") -> v.trim('"').split(":").firstOrNull()?.toIntOrNull()
-                ?: DEFAULT_START_OF_DAY_HOUR
-            else -> v.toIntOrNull() ?: DEFAULT_START_OF_DAY_HOUR
         }
     }
 

--- a/mobile/src/test/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdaterTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/widget/CategoryTimeWidgetUpdaterTest.kt
@@ -2,8 +2,23 @@ package net.activitywatch.android.widget
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.threeten.bp.LocalTime
 
 class CategoryTimeWidgetUpdaterTest {
+
+    @Test
+    fun parseStartOfDay_readsMinutesFromNativeSetting() {
+        assertEquals(
+            LocalTime.of(4, 30),
+            CategoryTimeWidgetUpdater.parseStartOfDay("\"04:30\"")
+        )
+    }
+
+    @Test
+    fun parseStartOfDay_fallsBackForMissingOrInvalidSetting() {
+        assertEquals(LocalTime.of(4, 0), CategoryTimeWidgetUpdater.parseStartOfDay("null"))
+        assertEquals(LocalTime.of(4, 0), CategoryTimeWidgetUpdater.parseStartOfDay("\"99:00\""))
+    }
 
     private fun catEvent(duration: Double, vararg category: String): String {
         val cats = category.joinToString(",") { "\"$it\"" }

--- a/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/workers/NotifyWorkerTest.kt
@@ -8,6 +8,30 @@ import org.threeten.bp.LocalDateTime
 
 class NotifyWorkerTest {
     @Test
+    fun parseStartOfDayHour_readsNativeSettingAndFallsBack() {
+        assertEquals(6, parseStartOfDayHour("\"06:00\""))
+        assertEquals(4, parseStartOfDayHour("null"))
+        assertEquals(4, parseStartOfDayHour("\"99:00\""))
+    }
+
+    @Test
+    fun alertsFromSetting_readsNativeSetting() {
+        val alerts = alertsFromSetting(
+            """[{"category":"Work","label":"Focus","thresholdMinutes":[30]}]"""
+        )
+
+        assertEquals(1, alerts.size)
+        assertEquals("Focus", alerts[0].label)
+        assertEquals(listOf(30), alerts[0].thresholdMinutes)
+    }
+
+    @Test
+    fun alertsFromSetting_fallsBackForMissingOrInvalidSetting() {
+        assertEquals("All", alertsFromSetting("null")[0].label)
+        assertEquals("All", alertsFromSetting("not-json")[0].label)
+    }
+
+    @Test
     fun logicalDayDate_usesPreviousDateBeforeConfiguredBoundary() {
         val now = LocalDateTime.of(2026, 7, 24, 3, 59)
 


### PR DESCRIPTION
## What

- bump aw-server-rust to the merged ActivityWatch/aw-server-rust#653 commit
- expose the native getSetting JNI method to Kotlin
- read widget startOfDay and NotifyWorker startOfDay / aw-notify directly from SQLite instead of unauthenticated localhost HTTP
- cover valid, missing, and malformed native setting values in unit tests

## Why

Android enables bearer authentication by default. The widget and background worker did not send that token, so their localhost settings requests returned 401 (or failed when the HTTP server was down) and silently used defaults. The widget then classified the same events with different category rules than the Activity view.

ActivityWatch/aw-server-rust#653 fixes androidQuery by loading settings.classes from the datastore and adds the matching getSetting JNI method for the remaining background settings reads.

## Verification

- full debug unit suite: ./gradlew :mobile:testDebugUnitTest
- targeted widget and NotifyWorker tests pass (19 tests)
- PR quality gate: 94/100, OPEN
- no localhost settings HTTP calls remain in widget or NotifyWorker

## Deliberate scope

- localStorage-only class migration stays in aw-webui. Automatically writing a browser fallback from Android could overwrite settings from another browser; saving Categorization settings once already persists settings.classes.
- NotifyWorker's pre-existing hour-only startOfDay model is unchanged; the widget continues to preserve minutes.
- #235 also changes the aw-server-rust gitlink. Whichever submodule bump lands second must use a master descendant containing both #653 and #654.

Refs ActivityWatch/aw-android#142. Device confirmation with custom categories remains before the issue itself is complete.
