### PR TITLE
ci(release): generate release notes instead of shipping an empty body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -458,10 +458,13 @@ jobs:
     # build_changelog.py is maintained in ActivityWatch/activitywatch and is
     # explicitly designed to be reused by other repos (see its module docstring).
     # Check it out rather than vendoring a copy that would drift.
+    # Pinned to a known-good commit (2026-08-24) to avoid executing unpinned
+    # upstream scripts inside a release-capable job.
     - name: Checkout changelog tooling
       uses: actions/checkout@v4
       with:
         repository: ActivityWatch/activitywatch
+        ref: a17fa8aff7465268973a10d7d43aeb6741492e03
         path: .changelog-tools
         sparse-checkout: scripts
         fetch-depth: 1
@@ -497,7 +500,17 @@ jobs:
         # get_latest_release.sh excludes the tag being released, so this
         # resolves to the previous release. STABLE_ONLY makes a stable release
         # diff against the last stable one rather than the last beta.
-        LAST_RELEASE=$(STABLE_ONLY=${{ steps.version.outputs.is_stable }} \
+        # NOTE: check-version-format-action classifies 0.x.x as not stable per
+        # semver, but aw-android uses 0.x.x for production releases. Use the
+        # same regex the release-play job uses to detect stability correctly.
+        TAG="${{ github.ref_name }}"
+        VERSION="${TAG#v}"
+        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          IS_STABLE="true"
+        else
+          IS_STABLE="false"
+        fi
+        LAST_RELEASE=$(STABLE_ONLY=${IS_STABLE} \
           .changelog-tools/scripts/get_latest_release.sh)
         if [ -z "$LAST_RELEASE" ]; then
           echo "No previous release tag found; falling back to nearest ancestor tag."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,6 +447,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    # Needed for changelog generation: full history + tags, and the submodule
+    # pointers build_changelog.py summarizes (aw-server-rust).
+    # Must run before download-artifact, since checkout cleans the workspace.
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    # build_changelog.py is maintained in ActivityWatch/activitywatch and is
+    # explicitly designed to be reused by other repos (see its module docstring).
+    # Check it out rather than vendoring a copy that would drift.
+    - name: Checkout changelog tooling
+      uses: actions/checkout@v4
+      with:
+        repository: ActivityWatch/activitywatch
+        path: .changelog-tools
+        sparse-checkout: scripts
+        fetch-depth: 1
+
     # Will download all artifacts to path
     - name: Download release APK & AAB
       uses: actions/download-artifact@v4
@@ -465,6 +484,34 @@ jobs:
       with:
         prefix: 'v'
 
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Install changelog deps
+      run: pip install requests
+
+    - name: Generate release notes
+      run: |
+        # get_latest_release.sh excludes the tag being released, so this
+        # resolves to the previous release. STABLE_ONLY makes a stable release
+        # diff against the last stable one rather than the last beta.
+        LAST_RELEASE=$(STABLE_ONLY=${{ steps.version.outputs.is_stable }} \
+          .changelog-tools/scripts/get_latest_release.sh)
+        if [ -z "$LAST_RELEASE" ]; then
+          echo "No previous release tag found; falling back to nearest ancestor tag."
+          LAST_RELEASE=$(git describe --tags --abbrev=0 \
+            --exclude "$GITHUB_REF_NAME" "$GITHUB_REF_NAME")
+        fi
+        echo "Generating changelog for $LAST_RELEASE...$GITHUB_REF_NAME"
+        python3 .changelog-tools/scripts/build_changelog.py \
+          --org ActivityWatch --repo aw-android \
+          --project-title "ActivityWatch for Android" \
+          --range "$LAST_RELEASE...$GITHUB_REF_NAME" \
+          --output release_notes.md
+        cat release_notes.md
+
     # create a release
     - name: Release
       uses: softprops/action-gh-release@v2
@@ -474,4 +521,4 @@ jobs:
         files: |
           dist/*.apk
           dist/*.aab
-        # body_path: dist/release_notes/release_notes.md
+        body_path: release_notes.md


### PR DESCRIPTION
Fixes item 1 of ActivityWatch/aw-android#236.

## Problem

`release-gh` created GitHub releases with **no description**. `body_path` was commented out, and nothing generated the file it pointed at:

```yaml
        # body_path: dist/release_notes/release_notes.md
```

That's why v0.14.0b2 went to the Play Store stable channel with an empty changelog.

## Fix

Wire up the same generator the main ActivityWatch and gptme repos use. `build_changelog.py` explicitly supports cross-repo reuse:

> NOTE: This script can be downloaded as-is and run from your repository.
> Repos using this script: ActivityWatch/activitywatch, ErikBjare/gptme

So it's checked out from `ActivityWatch/activitywatch` (sparse, `scripts/` only) rather than vendoring a copy that would drift out of sync.

Three things this needed:

1. **A checkout.** The job never checked out the repo at all — it only downloaded artifacts. Added with `fetch-depth: 0` (needs full history + tags to resolve the previous release and walk the range) and `submodules: recursive` so aw-server-rust changes appear in the notes when the pointer moves. It runs *before* `download-artifact`, since checkout cleans the workspace.
2. **Previous-release resolution.** `get_latest_release.sh` filters out the tag being released, so it resolves to the previous one. `STABLE_ONLY` is fed from the existing `check-version-format-action` output, so a stable release diffs against the last stable rather than the last beta. Falls back to the nearest ancestor tag if no prior release matches.
3. **Uncommenting `body_path`.**

## Verification

Ran the generator locally against the real `v0.14.0b1...v0.14.0b2` range. It resolves the previous tag correctly (`v0.14.0b1`) and produces a contributor list plus a categorized changelog covering all 9 commits:

```
These are the release notes for ActivityWatch for Android version v0.14.0b2.

# Contributors

Thanks to everyone who contributed to this release:

@0xbrayo, @erikbjare, @Lorite, @TimeToBuildBob

# Changelog

Changes since v0.14.0b1:

## 📦 aw-android

### ✨ Features (1)
 - feat: add Material You monochrome launcher icon (#230)

### 🐛 Fixes (7)
 - fix: save bucket exports from the WebView instead of dropping them (#229)
 - fix(sync): make Sync Settings reachable from the navigation drawer (#221)
 - fix(notify): open MainActivity when notification is tapped (#225)
 - fix(sync): make the SAF mirror recursive and structure-preserving (#222)
 - fix(notify): use ActivityWatch logo as notification small icon (#227)
 - fix(widget): group category time by full path (#231)
 - fix: reword foreground notification to not expose internals (#223)

### 🔨 Misc (1)
 - chore: bump versionName to 0.14.0b2, versionCode to 40
```

Also confirmed the workflow YAML parses and the step ordering is correct.

## Notes

- Releases stay `draft: true` — this only fills in the body, so the release is still reviewed before publishing.
- No conflict with #212 (also touches `build.yml`, but in the `build-apk` signing job); verified with `git merge-tree`.
- The generator runs unauthenticated against the GitHub API for contributor lookup, same as the main repo.