### PR TITLE
fix(android): report app version in aw-server-rust info endpoint

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -33,6 +33,7 @@ class RustInterface(context: Context? = null) {
         initialize()
         if (context != null) {
             setDataDir(context.filesDir.absolutePath)
+            setVersionOverride(BuildConfig.VERSION_NAME)
         }
     }
 
@@ -44,6 +45,7 @@ class RustInterface(context: Context? = null) {
     private external fun greeting(pattern: String): String
     private external fun startServer()
     private external fun setDataDir(path: String)
+    private external fun setVersionOverride(version: String)
     external fun getBuckets(): String
     external fun createBucket(bucket: String): String
     external fun getEvents(bucket_id: String, limit: Int): String


### PR DESCRIPTION
Fixes item 3 of ActivityWatch/aw-android#236.

## Problem

The footer in the webui showed `v0.14.0 (rust)` — the Cargo.toml version of the embedded aw-server-rust component — while the installed app was `v0.14.0b2`. The two diverge because aw-server-rust has its own release cadence and its `Cargo.toml` version is a component version, not the Android app version.

## Fix

ActivityWatch/aw-server-rust#656 (merged 2026-08-25) added a `setVersionOverride` JNI entrypoint that accepts a version string and uses it verbatim in `GET /api/0/info`. This PR wires it up on the Android side:

1. **Declare the external fun** — `private external fun setVersionOverride(version: String)`, mirroring the existing `setDataDir` pattern.
2. **Call it at startup** — in `init {}`, immediately after `setDataDir(context.filesDir.absolutePath)`, call `setVersionOverride(BuildConfig.VERSION_NAME)`. `BuildConfig.VERSION_NAME` carries the release version (e.g. `0.14.0b2`) set by the build system.
3. **Bump the submodule** — updates `aw-server-rust` from `75722f3` to `77defef` to pick up #656.

After this change `GET /api/0/info` returns the Android release version, so the footer will read `v0.14.0b2 (rust)` (or whatever `VERSION_NAME` the build sets) instead of a stale Cargo version.