### PR TITLE
fix(android): report the app's version from /api/0/info

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/RustInterface.kt
@@ -1,6 +1,7 @@
 package net.activitywatch.android
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
@@ -33,6 +34,32 @@ class RustInterface(context: Context? = null) {
         initialize()
         if (context != null) {
             setDataDir(context.filesDir.absolutePath)
+            appVersionString(context)?.let { setVersionOverride(it) }
+        }
+    }
+
+    /**
+     * The version to report from `GET /api/0/info`, which the webui footer shows.
+     *
+     * Without an override the server reports the aw-server-rust package version,
+     * which is the version of a component rather than of the app the user
+     * installed: the footer read `v0.14.0 (rust)` on a `v0.14.0b2` install.
+     *
+     * The `(rust)` suffix is kept deliberately — aw-webui checks the version
+     * string for it to decide whether to offer the API browser link, which
+     * aw-server-rust does not serve.
+     *
+     * Returns null if the version can't be read, leaving the server's default.
+     */
+    private fun appVersionString(context: Context): String? {
+        return try {
+            val versionName =
+                context.packageManager.getPackageInfo(context.packageName, 0).versionName
+                    ?: return null
+            "v$versionName (rust)"
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.w(TAG, "Could not read the app's own version, reporting the server's", e)
+            null
         }
     }
 
@@ -44,6 +71,7 @@ class RustInterface(context: Context? = null) {
     private external fun greeting(pattern: String): String
     private external fun startServer()
     private external fun setDataDir(path: String)
+    private external fun setVersionOverride(version: String)
     external fun getBuckets(): String
     external fun createBucket(bucket: String): String
     external fun getEvents(bucket_id: String, limit: Int): String


### PR DESCRIPTION
Android half of item 3 in #236, the follow-up to ActivityWatch/aw-server-rust#656 (merged).

## Problem

The webui footer showed `v0.14.0 (rust)` on a `v0.14.0b2` install: `GET /api/0/info` reported the aw-server-rust **package** version, which is the version of a component rather than of the app the user installed.

## Fix

- Bump the `aw-server-rust` submodule to pick up `setVersionOverride` (ActivityWatch/aw-server-rust#656).
- Declare the `setVersionOverride` external and call it from `RustInterface`'s `init`, right next to the existing `setDataDir` call, so the override is set before the server starts.

The version is read via `packageManager.getPackageInfo(...).versionName` — the same mechanism `MainActivity.version` already uses. That avoids turning on the `buildConfig` build feature (off by default since AGP 8) just to reach `BuildConfig.VERSION_NAME`.

## Why the `(rust)` suffix stays

The reported string becomes `v0.14.0b2 (rust)` rather than a bare `v0.14.0b2`. aw-webui sniffs the version string for `rust`:

```pug
li(v-if="!info.version.includes('rust')") #[a(:href="apiBrowserUrl") {{ $t('home.apiBrowser') }}]
```

Dropping the suffix would make the API browser link appear on Android, pointing at an endpoint aw-server-rust doesn't serve. The issue is that the *version number* was wrong, so only that is changed.

If the version can't be read, the override is skipped and the server keeps its current default — no behaviour change on that path.

## Verification

`./gradlew :mobile:compileDebugKotlin` — this repo has no unit tests covering `RustInterface` (it's a JNI shim), so the real check is CI's build plus a manual look at the footer on a debug build.

Part of #236.