### PR TITLE
ci(release): fail the release job when the changelog is empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,6 +524,13 @@ jobs:
           --range "$LAST_RELEASE...$GITHUB_REF_NAME" \
           --output release_notes.md
         cat release_notes.md
+        # v0.14.0b2 shipped with an empty changelog because nothing generated
+        # release_notes.md. Fail loudly here rather than publishing a release
+        # whose body is silently blank.
+        if [ ! -s release_notes.md ]; then
+          echo "::error::release_notes.md is empty — refusing to publish a release with no changelog"
+          exit 1
+        fi
 
     # create a release
     - name: Release


### PR DESCRIPTION
Follow-up to #238, covering the "don't ship a release with no changelog" half of @ErikBjare's question on #236.

## What actually went wrong with v0.14.0b2

It was **not** stuck in draft — `gh release view v0.14.0b2 --json isDraft,body` reports `isDraft: false`, `body: ""`. It was published, with a blank body, because `body_path` was commented out and nothing generated `release_notes.md`. #238 fixed the generation; nothing yet fails when generation silently produces nothing.

## Fix

Assert `release_notes.md` is non-empty before `softprops/action-gh-release` runs. A blank changelog now fails the release job with a GitHub error annotation instead of shipping.

Deliberately at the generation site rather than as a post-release check: here the failure is still recoverable by re-running the workflow, whereas an empty published release body is effectively permanent.

## Note on the `draft:` change discussed in #236

This PR doesn't touch `draft:` — the two are orthogonal, and drafts weren't what caused the b2 problem. But one gotcha for whoever implements the prerelease-linked version suggested in the issue thread: the `is_prerelease`/`is_stable` output can't be used directly in this repo.

The `release-gh` job's step id is `version`, not `check_version`, and there's an existing comment at line 503 explaining why its output is untrustworthy here:

> `check-version-format-action` classifies 0.x.x as not stable per semver, but aw-android uses 0.x.x for production releases.

The job already works around this by computing stability itself with a regex, and `prerelease:` on line 540 uses `steps.version.outputs.is_stable` — which by that comment's own logic is wrong for every `v0.14.0`-style stable release. So a `draft:` change probably wants to reuse the locally-computed `IS_STABLE` (promoted to a step output), and it's worth checking whether `prerelease:` has the same latent bug.