### PR TITLE
fix(notify): open the activity view when an alert is tapped

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -16,13 +16,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
 import net.activitywatch.android.databinding.ActivityMainBinding
 import net.activitywatch.android.fragments.TestFragment
 import net.activitywatch.android.fragments.WebUIFragment
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.launch
 import net.activitywatch.android.watcher.UsageStatsWatcher
 
 private const val TAG = "MainActivity"
@@ -38,6 +39,9 @@ internal fun activityViewUrl(baseUrl: String = baseURL): String = "$baseUrl$ACTI
 
 internal fun initialWebUiUrl(openActivityView: Boolean, baseUrl: String = baseURL): String =
     if (openActivityView) activityViewUrl(baseUrl) else baseUrl
+
+internal fun shouldOpenActivityViewImmediately(openActivityView: Boolean, isResumed: Boolean): Boolean =
+    openActivityView && isResumed
 
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener, WebUIFragment.OnFragmentInteractionListener {
@@ -140,9 +144,17 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        // Do not commit fragments here. onNewIntent runs while the activity is
-        // still stopped (after onSaveInstanceState); commit() would throw.
-        // onResume performs the replace once the FragmentManager is ready.
+
+        val isResumed = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        if (shouldOpenActivityViewImmediately(
+                intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false),
+                isResumed,
+            )
+        ) {
+            openPendingActivityView()
+        }
+        // A stopped activity cannot safely commit here because its fragment
+        // state may already be saved. onResume consumes the intent instead.
     }
 
     private fun takeOpenActivityView(intent: Intent): Boolean {
@@ -164,15 +176,19 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         transaction.commit()
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        // Notification tap on a reused/restored instance: replace after the
-        // FragmentManager is ready. Cold start already consumed the extra in
-        // onCreate, so this is a no-op there.
+    private fun openPendingActivityView() {
         if (takeOpenActivityView(intent)) {
             showWebUi(activityViewUrl(), replace = true)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Notification tap on a stopped/restored instance: replace after the
+        // FragmentManager is ready. Cold start and resumed delivery already
+        // consumed the extra, so this is a no-op in those cases.
+        openPendingActivityView()
 
         // Ensures data is always fresh when app is opened,
         // even if it was up to an hour since the last logging-alarm was triggered.

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -124,25 +124,25 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
         })
 
-        // Honor a notification tap even when the system restores a previous
-        // fragment (process death). Consume the extra so a later rotation
-        // does not replace the restored WebView with a fresh one.
-        val openActivityView = takeOpenActivityView(intent)
         if (savedInstanceState != null) {
-            if (openActivityView) {
-                showWebUi(activityViewUrl(), replace = true)
-            }
             return
         }
+        // Cold start: pick the right first fragment so we don't flash dashboard
+        // home before onResume. Consume the extra here; onResume is the path
+        // for reused instances (onNewIntent) and process-death restore.
+        val openActivityView = intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)
         showWebUi(initialWebUiUrl(openActivityView), replace = false)
+        if (openActivityView) {
+            intent.removeExtra(EXTRA_OPEN_ACTIVITY_VIEW)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        if (takeOpenActivityView(intent)) {
-            showWebUi(activityViewUrl(), replace = true)
-        }
+        // Do not commit fragments here. onNewIntent runs while the activity is
+        // still stopped (after onSaveInstanceState); commit() would throw.
+        // onResume performs the replace once the FragmentManager is ready.
     }
 
     private fun takeOpenActivityView(intent: Intent): Boolean {
@@ -166,6 +166,13 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     override fun onResume() {
         super.onResume()
+
+        // Notification tap on a reused/restored instance: replace after the
+        // FragmentManager is ready. Cold start already consumed the extra in
+        // onCreate, so this is a no-op there.
+        if (takeOpenActivityView(intent)) {
+            showWebUi(activityViewUrl(), replace = true)
+        }
 
         // Ensures data is always fresh when app is opened,
         // even if it was up to an hour since the last logging-alarm was triggered.

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -29,6 +29,16 @@ private const val TAG = "MainActivity"
 
 const val baseURL = "http://127.0.0.1:5600"
 
+// Same destination as the drawer "Activity" item. Notification taps set
+// EXTRA_OPEN_ACTIVITY_VIEW so we land here instead of dashboard home.
+const val ACTIVITY_VIEW_ROUTE = "/#/activity/unknown/"
+const val EXTRA_OPEN_ACTIVITY_VIEW = "net.activitywatch.android.extra.OPEN_ACTIVITY_VIEW"
+
+internal fun activityViewUrl(baseUrl: String = baseURL): String = "$baseUrl$ACTIVITY_VIEW_ROUTE"
+
+internal fun initialWebUiUrl(openActivityView: Boolean, baseUrl: String = baseURL): String =
+    if (openActivityView) activityViewUrl(baseUrl) else baseUrl
+
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener, WebUIFragment.OnFragmentInteractionListener {
 
@@ -104,13 +114,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         val serviceIntent = Intent(this, BackgroundService::class.java)
         startForegroundService(serviceIntent)
 
-        if (savedInstanceState != null) {
-            return
-        }
-        val firstFragment = WebUIFragment.newInstance(authenticatedUrl())
-        supportFragmentManager.beginTransaction()
-            .add(R.id.fragment_container, firstFragment).commit()
-
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (binding.drawerLayout.isDrawerOpen(GravityCompat.START)) {
@@ -121,6 +124,32 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
         })
 
+        if (savedInstanceState != null) {
+            return
+        }
+        showWebUi(
+            initialWebUiUrl(intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)),
+            replace = false,
+        )
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)) {
+            showWebUi(activityViewUrl(), replace = true)
+        }
+    }
+
+    private fun showWebUi(url: String, replace: Boolean) {
+        val fragment = WebUIFragment.newInstance(authenticatedUrl(url))
+        val transaction = supportFragmentManager.beginTransaction()
+        if (replace) {
+            transaction.replace(R.id.fragment_container, fragment)
+        } else {
+            transaction.add(R.id.fragment_container, fragment)
+        }
+        transaction.commit()
     }
 
     override fun onResume() {
@@ -168,7 +197,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
             R.id.nav_activity -> {
                 fragmentClass = WebUIFragment::class.java
-                url = authenticatedUrl("$baseURL/#/activity/unknown/")
+                url = authenticatedUrl(activityViewUrl())
             }
             R.id.nav_buckets -> {
                 fragmentClass = WebUIFragment::class.java

--- a/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/MainActivity.kt
@@ -124,21 +124,33 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
         })
 
+        // Honor a notification tap even when the system restores a previous
+        // fragment (process death). Consume the extra so a later rotation
+        // does not replace the restored WebView with a fresh one.
+        val openActivityView = takeOpenActivityView(intent)
         if (savedInstanceState != null) {
+            if (openActivityView) {
+                showWebUi(activityViewUrl(), replace = true)
+            }
             return
         }
-        showWebUi(
-            initialWebUiUrl(intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)),
-            replace = false,
-        )
+        showWebUi(initialWebUiUrl(openActivityView), replace = false)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        if (intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)) {
+        if (takeOpenActivityView(intent)) {
             showWebUi(activityViewUrl(), replace = true)
         }
+    }
+
+    private fun takeOpenActivityView(intent: Intent): Boolean {
+        val open = intent.getBooleanExtra(EXTRA_OPEN_ACTIVITY_VIEW, false)
+        if (open) {
+            intent.removeExtra(EXTRA_OPEN_ACTIVITY_VIEW)
+        }
+        return open
     }
 
     private fun showWebUi(url: String, replace: Boolean) {

--- a/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
+++ b/mobile/src/main/java/net/activitywatch/android/workers/NotifyWorker.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.jakewharton.threetenabp.AndroidThreeTen
+import net.activitywatch.android.EXTRA_OPEN_ACTIVITY_VIEW
 import net.activitywatch.android.MainActivity
 import net.activitywatch.android.R
 import net.activitywatch.android.RustInterface
@@ -209,9 +210,14 @@ class NotifyWorker(context: Context, params: WorkerParameters) : Worker(context,
         val body = "${alert.label}: $thresholdStr" +
             if (thresholdStr != actualStr) "  ($actualStr)" else ""
 
-        // Open the activity/timeline view in MainActivity when the notification is tapped.
+        // Open the activity/timeline view (same destination as the drawer
+        // "Activity" item) when the notification is tapped. SINGLE_TOP lets an
+        // already-running MainActivity receive onNewIntent instead of stacking.
         val openIntent = Intent(applicationContext, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(EXTRA_OPEN_ACTIVITY_VIEW, true)
         }
         val pendingIntent = PendingIntent.getActivity(
             applicationContext,

--- a/mobile/src/test/java/net/activitywatch/android/MainActivityNavigationTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/MainActivityNavigationTest.kt
@@ -1,6 +1,8 @@
 package net.activitywatch.android
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MainActivityNavigationTest {
@@ -14,6 +16,20 @@ class MainActivityNavigationTest {
         assertEquals(
             "$baseURL/#/activity/unknown/",
             initialWebUiUrl(openActivityView = true),
+        )
+    }
+
+    @Test
+    fun notificationIntent_navigatesImmediatelyWhenActivityIsResumed() {
+        assertTrue(
+            shouldOpenActivityViewImmediately(openActivityView = true, isResumed = true),
+        )
+    }
+
+    @Test
+    fun notificationIntent_defersNavigationWhenActivityIsStopped() {
+        assertFalse(
+            shouldOpenActivityViewImmediately(openActivityView = true, isResumed = false),
         )
     }
 }

--- a/mobile/src/test/java/net/activitywatch/android/MainActivityNavigationTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/MainActivityNavigationTest.kt
@@ -1,0 +1,19 @@
+package net.activitywatch.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MainActivityNavigationTest {
+    @Test
+    fun initialWebUiUrl_defaultsToDashboardHome() {
+        assertEquals(baseURL, initialWebUiUrl(openActivityView = false))
+    }
+
+    @Test
+    fun initialWebUiUrl_opensActivityNavDestination() {
+        assertEquals(
+            "$baseURL/#/activity/unknown/",
+            initialWebUiUrl(openActivityView = true),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

#225 attached a `MainActivity` PendingIntent, so tapping an activity-time alert no longer did nothing. It still opened dashboard home (`http://127.0.0.1:5600`) rather than the Activity view.

## Fix

- Pass `EXTRA_OPEN_ACTIVITY_VIEW` on the existing NotifyWorker PendingIntent
- `FLAG_ACTIVITY_SINGLE_TOP` so a running `MainActivity` gets `onNewIntent` instead of stacking
- Load the same URL as the drawer Activity item (`/#/activity/unknown/`)
- Honor the extra after process death (`savedInstanceState` restore) and consume it so rotation does not reload the WebView

#234 also edits `NotifyWorker.kt`, but only `parseCategorySeconds`. This PR only changes `sendNotification`. Should merge cleanly.

Fixes #224