### PR TITLE
fix(sync): pick up aw-server-rust API-key JNI client and set data dir

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -53,8 +53,12 @@ class SyncInterface(context: Context) {
         Os.setenv("XDG_CACHE_HOME", cacheDir, true)
         Os.setenv("XDG_CONFIG_HOME", "$filesDir/config", true)
         Os.setenv("XDG_DATA_HOME", "$filesDir/data", true)
-        
+
         System.loadLibrary("aw_sync")
+        // libaw_sync.so has its own ANDROID_DATA_DIR static; RustInterface.setDataDir
+        // only updates libaw_server.so. Point this copy at filesDir so sync reads
+        // the same config.toml as the embedded server (ActivityWatch/aw-server-rust#666).
+        setDataDir(filesDir)
         Log.i(TAG, "aw-sync initialized with sync dir: $syncDir")
     }
 
@@ -72,6 +76,7 @@ class SyncInterface(context: Context) {
     }
     
     // Native JNI functions
+    private external fun setDataDir(path: String)
     private external fun syncPullAll(port: Int, hostname: String): String
     private external fun syncPull(port: Int, hostname: String): String
     private external fun syncPush(port: Int, hostname: String): String


### PR DESCRIPTION
Follow-up to ActivityWatch/aw-server-rust#666 (merged). Ships the v0.14.0b2 sync 401 fix into the app ([ActivityWatch/aw-android#247](https://github.com/ActivityWatch/aw-android/issues/247)).

## Problem

Sync appeared to run but the chosen folder never changed: `GET /api/0/buckets` 401'd because the Android JNI client did not forward `[auth].api_key` from `filesDir/config.toml`.

## Fix

- Bump `aw-server-rust` `77defef` → `2ded7d7` (includes #666).
- Call `SyncInterface.setDataDir(filesDir)` after `loadLibrary("aw_sync")`. `libaw_sync.so` has its own `ANDROID_DATA_DIR` static; `RustInterface.setDataDir` only updates `libaw_server.so`. The hardcoded default is the release user-0 path — debug (`.debug` suffix) and work-profile installs still 401 without this.

XDG env (`XDG_DATA_HOME=$filesDir/data`) stays as the fallback for current Kotlin that had not called `setDataDir`.

Also picked up in the same bump: #654 (Rust panics to logcat, #220), #657, #658, #660, #661, #642.

Does not close #247: remaining items are sync UX/discoverability and category-import save persistence.

## Testing

- JNI symbol `Java_net_activitywatch_android_SyncInterface_setDataDir` present at the pinned SHA.
- Local `:mobile:compileDebugKotlin` not run here (no JAVA_HOME on this host); CI build is the check.
