### PR TITLE
feat(sync): show last completion status

### DIFF
--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -5,7 +5,15 @@ import android.content.SharedPreferences
 
 class AWPreferences(context: Context) {
     private val sharedPreferences: SharedPreferences =
-        context.getSharedPreferences("AWPreferences", Context.MODE_PRIVATE)
+        context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    companion object {
+        const val PREFERENCES_NAME = "AWPreferences"
+        const val LAST_SYNC_STATUS_CHANGED_ACTION =
+            "net.activitywatch.android.LAST_SYNC_STATUS_CHANGED"
+    }
+
+    private val appContext = context.applicationContext
 
     // To check if it is the first time the app is being run
     // Set to false when user finishes onboarding
@@ -91,6 +99,9 @@ class AWPreferences(context: Context) {
             .putLong("lastSyncCompletedAt", status.completedAt)
             .putBoolean("lastSyncSucceeded", status.success)
             .apply()
+        appContext.sendBroadcast(
+            android.content.Intent(LAST_SYNC_STATUS_CHANGED_ACTION).setPackage(appContext.packageName)
+        )
     }
 
     // Dashboard authentication. Defaults to true so first-run gets a key generated

--- a/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
+++ b/mobile/src/main/java/net/activitywatch/android/AWPreferences.kt
@@ -76,6 +76,23 @@ class AWPreferences(context: Context) {
         sharedPreferences.edit().putString("syncDirUri", uri).apply()
     }
 
+    fun getLastSyncStatus(): SyncStatus? {
+        val completedAt = sharedPreferences.getLong("lastSyncCompletedAt", 0L)
+        if (completedAt == 0L) return null
+
+        return SyncStatus(
+            completedAt = completedAt,
+            success = sharedPreferences.getBoolean("lastSyncSucceeded", false),
+        )
+    }
+
+    fun setLastSyncStatus(status: SyncStatus) {
+        sharedPreferences.edit()
+            .putLong("lastSyncCompletedAt", status.completedAt)
+            .putBoolean("lastSyncSucceeded", status.success)
+            .apply()
+    }
+
     // Dashboard authentication. Defaults to true so first-run gets a key generated
     // automatically. Set to false when the user explicitly disables auth in settings;
     // ensureDashboardApiKey() checks this before generating a new key so that the

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -108,7 +108,7 @@ class SyncInterface(context: Context) {
     
     // Async wrapper for syncBoth
     fun syncBothAsync(callback: (Boolean, String) -> Unit) {
-        syncBothAsync(mirrorBeforeCallback = false, callback)
+        syncBothAsync(mirrorBeforeCallback = true, callback)
     }
 
     // Background workers must remain active until the SAF mirror completes.
@@ -189,20 +189,12 @@ class SyncInterface(context: Context) {
 
                 // Keep completion feedback honest: a configured SAF directory is part of a
                 // successful Android sync, so mirror failures must reach the user instead of
-                // being logged as a non-fatal success. Worker-triggered syncs wait for mirroring;
-                // Handler-triggered syncs keep the existing callback timing.
+                // being logged as a non-fatal success. Full-sync callers wait for mirroring.
                 Log.i(TAG, "$operation completed: success=$success, message=$message")
                 if (success && mirrorBeforeCallback) {
                     mirrorSyncFilesToSafDir()
                 }
                 handler.post { callback(success, message) }
-                if (success && !mirrorBeforeCallback) {
-                    try {
-                        copySyncFilesToSafDir()
-                    } catch (e: Exception) {
-                        Log.w(TAG, "SAF mirror failed after callback: ${e.message}", e)
-                    }
-                }
             } catch (e: Exception) {
                 val errorMsg = "Exception: ${e.message}"
                 handler.post {
@@ -251,6 +243,9 @@ class SyncInterface(context: Context) {
         val counts = intArrayOf(0, 0) // [copied, skipped]
         mirrorDirectory(File(syncDir), safDir, counts)
         Log.i(TAG, "SAF mirror: copied=${counts[0]} skipped=${counts[1]} → $uriStr")
+        if (counts[1] > 0) {
+            throw IOException("SAF mirror skipped ${counts[1]} item(s)")
+        }
     }
 
     /**

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -236,13 +236,15 @@ class SyncInterface(context: Context) {
         val safUri = Uri.parse(uriStr)
         val safDir = DocumentFile.fromTreeUri(appContext, safUri)
         if (safDir == null || !safDir.isDirectory) {
-            Log.w(TAG, "SAF directory not accessible or not a directory: $uriStr")
-            return
+            throw IOException("Configured SAF directory is not accessible")
         }
 
         val counts = intArrayOf(0, 0) // [copied, skipped]
         mirrorDirectory(File(syncDir), safDir, counts)
         Log.i(TAG, "SAF mirror: copied=${counts[0]} skipped=${counts[1]} → $uriStr")
+        if (cancelRequested) {
+            throw IOException("SAF mirror cancelled")
+        }
         if (counts[1] > 0) {
             throw IOException("SAF mirror skipped ${counts[1]} item(s)")
         }

--- a/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncInterface.kt
@@ -17,6 +17,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 private const val TAG = "SyncInterface"
 
+data class SyncStatus(
+    val completedAt: Long,
+    val success: Boolean,
+)
+
 class SyncInterface(context: Context) {
 
     companion object {
@@ -125,6 +130,12 @@ class SyncInterface(context: Context) {
             "Full Sync",
             { success, message ->
                 syncInFlight.set(false)
+                AWPreferences(appContext).setLastSyncStatus(
+                    SyncStatus(
+                        completedAt = System.currentTimeMillis(),
+                        success = success,
+                    )
+                )
                 callback(success, message)
             },
             mirrorBeforeCallback
@@ -176,15 +187,21 @@ class SyncInterface(context: Context) {
                     json.getString("error")
                 }
 
-                // Worker-triggered syncs keep their WorkManager job active until mirroring
-                // finishes. Other callers get the native result immediately.
+                // Keep completion feedback honest: a configured SAF directory is part of a
+                // successful Android sync, so mirror failures must reach the user instead of
+                // being logged as a non-fatal success. Worker-triggered syncs wait for mirroring;
+                // Handler-triggered syncs keep the existing callback timing.
                 Log.i(TAG, "$operation completed: success=$success, message=$message")
                 if (success && mirrorBeforeCallback) {
                     mirrorSyncFilesToSafDir()
                 }
                 handler.post { callback(success, message) }
                 if (success && !mirrorBeforeCallback) {
-                    mirrorSyncFilesToSafDir()
+                    try {
+                        copySyncFilesToSafDir()
+                    } catch (e: Exception) {
+                        Log.w(TAG, "SAF mirror failed after callback: ${e.message}", e)
+                    }
                 }
             } catch (e: Exception) {
                 val errorMsg = "Exception: ${e.message}"
@@ -199,11 +216,7 @@ class SyncInterface(context: Context) {
     }
 
     private fun mirrorSyncFilesToSafDir() {
-        try {
-            copySyncFilesToSafDir()
-        } catch (e: Exception) {
-            Log.w(TAG, "SAF mirror failed (non-fatal): ${e.message}")
-        }
+        copySyncFilesToSafDir()
     }
 
     /**
@@ -223,7 +236,8 @@ class SyncInterface(context: Context) {
      * `find_remotes` (`aw-sync/src/util.rs`) keeps only directories and looks for `*.db` one
      * level inside them, so a flattened copy would be ignored even if it were made.
      *
-     * Errors are logged but do not propagate — a copy failure must never fail the sync itself.
+     * Errors propagate to the caller so a configured directory is never reported as successfully
+     * synced when the files could not be mirrored there.
      */
     private fun copySyncFilesToSafDir() {
         val uriStr = AWPreferences(appContext).getSyncDirUri() ?: return

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -1,7 +1,10 @@
 package net.activitywatch.android
 
 import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
@@ -13,6 +16,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.appcompat.widget.SwitchCompat
 import java.text.DateFormat
 import java.util.Date
@@ -37,6 +41,14 @@ class SyncSettingsActivity : AppCompatActivity() {
 
     // Guards against the switch listener firing when we set isChecked programmatically
     private var isUpdatingSwitch = false
+
+    private val syncStatusReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == AWPreferences.LAST_SYNC_STATUS_CHANGED_ACTION) {
+                updateLastSyncStatus()
+            }
+        }
+    }
 
     private val openDocumentTree =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -125,9 +137,24 @@ class SyncSettingsActivity : AppCompatActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        ContextCompat.registerReceiver(
+            this,
+            syncStatusReceiver,
+            IntentFilter(AWPreferences.LAST_SYNC_STATUS_CHANGED_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+    }
+
     override fun onResume() {
         super.onResume()
         if (::prefs.isInitialized) refreshUI()
+    }
+
+    override fun onStop() {
+        unregisterReceiver(syncStatusReceiver)
+        super.onStop()
     }
 
     private fun refreshUI() {
@@ -135,6 +162,10 @@ class SyncSettingsActivity : AppCompatActivity() {
         switchSyncEnabled.isChecked = prefs.isSyncEnabled()
         isUpdatingSwitch = false
         updateSyncDirStatus()
+        updateLastSyncStatus()
+    }
+
+    private fun updateLastSyncStatus() {
         tvLastSyncStatus.text = formatSyncStatus(
             prefs.getLastSyncStatus(),
             combinedDateTimeFormat(),

--- a/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/SyncSettingsActivity.kt
@@ -14,8 +14,17 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
+import java.text.DateFormat
+import java.util.Date
 
 private const val TAG = "SyncSettingsActivity"
+
+internal fun formatSyncStatus(status: SyncStatus?, dateFormat: DateFormat): String {
+    if (status == null) return "Last sync: never"
+
+    val outcome = if (status.success) "succeeded" else "failed"
+    return "Last sync $outcome at ${dateFormat.format(Date(status.completedAt))}"
+}
 
 class SyncSettingsActivity : AppCompatActivity() {
 
@@ -23,6 +32,7 @@ class SyncSettingsActivity : AppCompatActivity() {
 
     private lateinit var switchSyncEnabled: SwitchCompat
     private lateinit var tvSyncDirStatus: TextView
+    private lateinit var tvLastSyncStatus: TextView
     private lateinit var btnChooseDir: Button
 
     // Guards against the switch listener firing when we set isChecked programmatically
@@ -91,6 +101,7 @@ class SyncSettingsActivity : AppCompatActivity() {
 
         switchSyncEnabled = findViewById(R.id.switch_sync_enabled)
         tvSyncDirStatus = findViewById(R.id.tv_sync_dir_status)
+        tvLastSyncStatus = findViewById(R.id.tv_last_sync_status)
         btnChooseDir = findViewById(R.id.btn_choose_sync_dir)
 
         refreshUI()
@@ -124,6 +135,27 @@ class SyncSettingsActivity : AppCompatActivity() {
         switchSyncEnabled.isChecked = prefs.isSyncEnabled()
         isUpdatingSwitch = false
         updateSyncDirStatus()
+        tvLastSyncStatus.text = formatSyncStatus(
+            prefs.getLastSyncStatus(),
+            combinedDateTimeFormat(),
+        )
+    }
+
+    private fun combinedDateTimeFormat(): DateFormat {
+        val dateFormat = android.text.format.DateFormat.getMediumDateFormat(this)
+        val timeFormat = android.text.format.DateFormat.getTimeFormat(this)
+        return object : DateFormat() {
+            override fun format(
+                date: Date,
+                toAppendTo: StringBuffer,
+                fieldPosition: java.text.FieldPosition,
+            ): StringBuffer = toAppendTo
+                .append(dateFormat.format(date))
+                .append(" ")
+                .append(timeFormat.format(date))
+
+            override fun parse(source: String, pos: java.text.ParsePosition): Date? = null
+        }
     }
 
     private fun updateSyncDirStatus() {

--- a/mobile/src/main/res/layout/activity_sync_settings.xml
+++ b/mobile/src/main/res/layout/activity_sync_settings.xml
@@ -42,6 +42,16 @@
             android:textColor="?android:attr/textColorSecondary"
             android:text="No sync directory configured." />
 
+        <!-- Last automatic sync result -->
+        <TextView
+            android:id="@+id/tv_last_sync_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="Last sync: never"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary" />
+
         <!-- Choose directory button -->
         <Button
             android:id="@+id/btn_choose_sync_dir"

--- a/mobile/src/test/java/net/activitywatch/android/SyncSettingsActivityTest.kt
+++ b/mobile/src/test/java/net/activitywatch/android/SyncSettingsActivityTest.kt
@@ -1,0 +1,46 @@
+package net.activitywatch.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+class SyncSettingsActivityTest {
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.ROOT).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+    @Test
+    fun formatSyncStatus_reportsNeverBeforeFirstAttempt() {
+        assertEquals("Last sync: never", formatSyncStatus(null, dateFormat))
+    }
+
+    @Test
+    fun formatSyncStatus_reportsSuccessfulAttempt() {
+        assertEquals(
+            "Last sync succeeded at 2026-09-01 01:30",
+            formatSyncStatus(
+                SyncStatus(
+                    completedAt = 1_788_226_200_000L,
+                    success = true,
+                ),
+                dateFormat,
+            ),
+        )
+    }
+
+    @Test
+    fun formatSyncStatus_reportsFailedAttempt() {
+        assertEquals(
+            "Last sync failed at 2026-09-01 01:30",
+            formatSyncStatus(
+                SyncStatus(
+                    completedAt = 1_788_226_200_000L,
+                    success = false,
+                ),
+                dateFormat,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

ActivityWatch/aw-android#247 reports that sync runs silently: users cannot tell whether it succeeded, failed, or when it last completed. A failed SAF mirror was also logged as non-fatal, so the app could report native sync success while the user-selected directory stayed unchanged.

## Fix

- Persist the timestamp and outcome of each full sync attempt.
- Show `Last sync: never`, `Last sync succeeded at …`, or `Last sync failed at …` in Sync Settings.
- Treat a failed configured-directory mirror as a failed worker sync instead of silently reporting success.
- Keep the status compact and avoid persisting native error details, which can include filesystem paths.

This addresses the feedback/status portion of #247. The 401 root cause, document picker, and `unknown` Activity route are already merged via #249, #248, and #250. Category-import persistence remains separate.

## Testing

```txt
JAVA_HOME=/opt/android-studio/jbr ANDROID_HOME=/home/bob/Android/Sdk \
  ./gradlew :mobile:testDebugUnitTest --no-daemon
```

Passed (full JVM unit-test suite).
